### PR TITLE
fix(chord_pro): strip CCLI repeat markers [||:] and [:||] so import succeeds

### DIFF
--- a/src/inputs/chord_pro/iter_part.rs
+++ b/src/inputs/chord_pro/iter_part.rs
@@ -66,10 +66,17 @@ impl<'a> PartIterator<'a> {
             return self.handle_pipe_chord();
         }
 
+        // CCLI SongSelect repeat markers [||:] and [:||] are not chords; strip them
+        // so import does not fail. See https://github.com/xilefmusics/chordlib/issues/6
+        let is_repeat_marker = matches!(chord.trim(), "||:" | ":||");
+
         let idx = self.line.find(['[', '{']).unwrap_or(self.line.len());
         let (text, rest) = self.line.split_at(idx);
         self.line = rest;
 
+        if is_repeat_marker {
+            return Some(("", text).try_into());
+        }
         Some((chord, text).try_into())
     }
 

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -80,3 +80,42 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
     .normalize()
     .clone())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::types::ChordRepresentation;
+
+    use super::*;
+
+    /// ChordPro with CCLI-style repeat markers [||:] and [:||] must import without error;
+    /// markers are stripped and only real chords (e.g. [G][C][D]) are parsed.
+    /// See: https://github.com/xilefmusics/chordlib/issues/6
+    #[test]
+    fn load_string_accepts_repeat_markers() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Verse}
+[||:][G][C][D][ :||]
+"#;
+        let song = load_string(input).expect("import must not fail on repeat markers");
+        assert_eq!(song.title.as_str(), "Test");
+        assert_eq!(song.sections.len(), 1);
+        assert_eq!(song.sections[0].lines.len(), 1);
+
+        let key = song.key.as_ref().unwrap();
+        let rep = ChordRepresentation::Default;
+        let chord_parts: Vec<&crate::types::Chord> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(
+            chord_parts.len(),
+            3,
+            "expected exactly three chords G, C, D"
+        );
+        assert_eq!(chord_parts[0].format(key, &rep), "G");
+        assert_eq!(chord_parts[1].format(key, &rep), "C");
+        assert_eq!(chord_parts[2].format(key, &rep), "D");
+    }
+}


### PR DESCRIPTION
## Summary

ChordPro files that contain CCLI SongSelect repeat markers `[||:]` and `[:||]` no longer cause import to fail. The parser treats these bracketed tokens as non-chords and strips them, so only real chords (e.g. `[G][C][D]`) are parsed.

Fixes #6

## Context

Issue #6: Import failed with `Parse("failed to parse the duration")` when lines contained `[||:]` or `[:||]` because the parser tried to interpret them as chord names and passed them to the chord parser.

## Implementation

- **`iter_part.rs`**: Before building a chord part, detect repeat markers by matching `chord.trim()` to `"||:"` or `":||"`. When matched, yield a part with empty chord and the marker text (so it is effectively stripped from the chord line). Comment references the issue.
- **`mod.rs`**: New test `load_string_accepts_repeat_markers` that loads a ChordPro string with `[||:]`, `[G][C][D]`, and `[ :||]`, and asserts the song loads, has one section/line, and exactly three chords (G, C, D).

No behaviour change for ChordPro files without these markers.

## Testing

- `cargo fmt` and `cargo clippy --all-targets --all-features` (no new warnings).
- `cargo test`: all tests pass, including `load_string_accepts_repeat_markers`.

## Breaking changes

None. Imports that previously failed on repeat markers now succeed; all other behaviour is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 86c954f0ce7a0b759f8246cd63312b71f2a1595b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->