### PR TITLE
Support `{repeat}` directive in ChordPro for section repeats

### DIFF
--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -35,6 +35,48 @@ fn parse_repeat_directive(line: &str) -> Result<Option<u32>, Error> {
     }
 }
 
+fn build_section_from_lines<'a, F>(
+    keyword: &str,
+    lines: &[&'a str],
+    make_iter: F,
+) -> Result<Section, Error>
+where
+    F: Fn(&'a str) -> PartIterator<'a>,
+{
+    let raw: Vec<&'a str> = lines.iter().filter(|l| !l.is_empty()).copied().collect();
+    let last_idx = raw.len().saturating_sub(1);
+    for (i, line) in raw.iter().enumerate() {
+        if parse_repeat_directive(line)?.is_some() && i != last_idx {
+            return Err(Error::Parse(
+                "{repeat} or {repeat: N} only allowed on last line of section".into(),
+            ));
+        }
+    }
+    let (content_lines, repeat_count) = if let Some(last) = raw.last() {
+        if let Some(n) = parse_repeat_directive(last)? {
+            (&raw[..raw.len() - 1], n)
+        } else {
+            (raw.as_slice(), 1u32)
+        }
+    } else {
+        (raw.as_slice(), 1u32)
+    };
+    let parsed = content_lines
+        .iter()
+        .map(|line| {
+            make_iter(line)
+                .collect::<Result<Vec<Part>, Error>>()
+                .map(Line::new)
+        })
+        .collect::<Result<Vec<Line>, Error>>()?;
+
+    Ok(Section::new_with_repeat(
+        keyword.into(),
+        parsed,
+        repeat_count,
+    ))
+}
+
 pub fn load(path: &str) -> Result<Song, Error> {
     load_string(&std::fs::read_to_string(path)?)
 }
@@ -61,37 +103,7 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
         &mut time,
     )
     .map(|(keyword, lines)| {
-        let raw: Vec<&str> = lines.iter().filter(|l| !l.is_empty()).copied().collect();
-        let last_idx = raw.len().saturating_sub(1);
-        for (i, line) in raw.iter().enumerate() {
-            if parse_repeat_directive(line)?.is_some() && i != last_idx {
-                return Err(Error::Parse(
-                    "{repeat} or {repeat: N} only allowed on last line of section".into(),
-                ));
-            }
-        }
-        let (content_lines, repeat_count) = if let Some(last) = raw.last() {
-            if let Some(n) = parse_repeat_directive(last)? {
-                (&raw[..raw.len() - 1], n)
-            } else {
-                (raw.as_slice(), 1u32)
-            }
-        } else {
-            (raw.as_slice(), 1u32)
-        };
-        let parsed = content_lines
-            .iter()
-            .map(|line| {
-                PartIterator::new(line, 96)
-                    .collect::<Result<Vec<Part>, Error>>()
-                    .map(Line::new)
-            })
-            .collect::<Result<Vec<Line>, Error>>()?;
-        Ok(Section::new_with_repeat(
-            keyword.into(),
-            parsed,
-            repeat_count,
-        ))
+        build_section_from_lines(keyword, &lines, |line| PartIterator::new(line, 96))
     })
     .collect::<Result<Vec<Section>, Error>>()?;
 
@@ -100,37 +112,9 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
     } else {
         SpaceSectionIterator::new(input)
             .map(|(keyword, lines)| {
-                let raw: Vec<&str> = lines.iter().filter(|l| !l.is_empty()).copied().collect();
-                let last_idx = raw.len().saturating_sub(1);
-                for (i, line) in raw.iter().enumerate() {
-                    if parse_repeat_directive(line)?.is_some() && i != last_idx {
-                        return Err(Error::Parse(
-                            "{repeat} or {repeat: N} only allowed on last line of section".into(),
-                        ));
-                    }
-                }
-                let (content_lines, repeat_count) = if let Some(last) = raw.last() {
-                    if let Some(n) = parse_repeat_directive(last)? {
-                        (&raw[..raw.len() - 1], n)
-                    } else {
-                        (raw.as_slice(), 1u32)
-                    }
-                } else {
-                    (raw.as_slice(), 1u32)
-                };
-                let parsed = content_lines
-                    .iter()
-                    .map(|line| {
-                        PartIterator::new(line, time.map(|(a, b)| 96 * a / b).unwrap_or(96))
-                            .collect::<Result<Vec<Part>, Error>>()
-                            .map(Line::new)
-                    })
-                    .collect::<Result<Vec<Line>, Error>>()?;
-                Ok(Section::new_with_repeat(
-                    keyword.into(),
-                    parsed,
-                    repeat_count,
-                ))
+                build_section_from_lines(keyword, &lines, |line| {
+                    PartIterator::new(line, time.map(|(a, b)| 96 * a / b).unwrap_or(96))
+                })
             })
             .collect::<Result<Vec<Section>, Error>>()?
     };

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -8,6 +8,33 @@ use iter_space_section::SpaceSectionIterator;
 use crate::error::Error;
 use crate::types::{Line, Part, Section, Song};
 
+/// If `line` is `{repeat}` or `{repeat: N}` (N ≥ 1), returns Some(repeat_count).
+/// `{repeat}` → 4. Otherwise returns None (not a repeat directive).
+/// Returns Err if it looks like a repeat directive but is invalid (e.g. `{repeat: 0}`).
+fn parse_repeat_directive(line: &str) -> Result<Option<u32>, Error> {
+    let line = line.trim();
+    if !line.starts_with('{') || !line.ends_with('}') {
+        return Ok(None);
+    }
+    let inner = line[1..line.len() - 1].trim();
+    if inner == "repeat" {
+        return Ok(Some(4));
+    }
+    if let Some(rest) = inner.strip_prefix("repeat:") {
+        let n: u32 = rest
+            .trim()
+            .parse()
+            .map_err(|_| Error::Parse("invalid repeat count".into()))?;
+        if n >= 1 {
+            Ok(Some(n))
+        } else {
+            Err(Error::Parse("repeat count must be at least 1".into()))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 pub fn load(path: &str) -> Result<Song, Error> {
     load_string(&std::fs::read_to_string(path)?)
 }
@@ -34,15 +61,37 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
         &mut time,
     )
     .map(|(keyword, lines)| {
-        let lines = lines
+        let raw: Vec<&str> = lines.iter().filter(|l| !l.is_empty()).copied().collect();
+        let last_idx = raw.len().saturating_sub(1);
+        for (i, line) in raw.iter().enumerate() {
+            if parse_repeat_directive(line)?.is_some() && i != last_idx {
+                return Err(Error::Parse(
+                    "{repeat} or {repeat: N} only allowed on last line of section".into(),
+                ));
+            }
+        }
+        let (content_lines, repeat_count) = if let Some(last) = raw.last() {
+            if let Some(n) = parse_repeat_directive(last)? {
+                (&raw[..raw.len() - 1], n)
+            } else {
+                (raw.as_slice(), 1u32)
+            }
+        } else {
+            (raw.as_slice(), 1u32)
+        };
+        let parsed = content_lines
             .iter()
-            .filter(|line| line.len() > 0)
             .map(|line| {
-                let parts = PartIterator::new(line, 96).collect::<Result<Vec<Part>, Error>>()?;
-                Ok(Line::new(parts))
+                PartIterator::new(line, 96)
+                    .collect::<Result<Vec<Part>, Error>>()
+                    .map(Line::new)
             })
             .collect::<Result<Vec<Line>, Error>>()?;
-        Ok(Section::new(keyword.into(), lines))
+        Ok(Section::new_with_repeat(
+            keyword.into(),
+            parsed,
+            repeat_count,
+        ))
     })
     .collect::<Result<Vec<Section>, Error>>()?;
 
@@ -51,17 +100,37 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
     } else {
         SpaceSectionIterator::new(input)
             .map(|(keyword, lines)| {
-                let lines = lines
+                let raw: Vec<&str> = lines.iter().filter(|l| !l.is_empty()).copied().collect();
+                let last_idx = raw.len().saturating_sub(1);
+                for (i, line) in raw.iter().enumerate() {
+                    if parse_repeat_directive(line)?.is_some() && i != last_idx {
+                        return Err(Error::Parse(
+                            "{repeat} or {repeat: N} only allowed on last line of section".into(),
+                        ));
+                    }
+                }
+                let (content_lines, repeat_count) = if let Some(last) = raw.last() {
+                    if let Some(n) = parse_repeat_directive(last)? {
+                        (&raw[..raw.len() - 1], n)
+                    } else {
+                        (raw.as_slice(), 1u32)
+                    }
+                } else {
+                    (raw.as_slice(), 1u32)
+                };
+                let parsed = content_lines
                     .iter()
-                    .filter(|line| line.len() > 0)
                     .map(|line| {
-                        let parts =
-                            PartIterator::new(line, time.map(|(a, b)| 96 * a / b).unwrap_or(96))
-                                .collect::<Result<Vec<Part>, Error>>()?;
-                        Ok(Line::new(parts))
+                        PartIterator::new(line, time.map(|(a, b)| 96 * a / b).unwrap_or(96))
+                            .collect::<Result<Vec<Part>, Error>>()
+                            .map(Line::new)
                     })
                     .collect::<Result<Vec<Line>, Error>>()?;
-                Ok(Section::new(keyword.into(), lines))
+                Ok(Section::new_with_repeat(
+                    keyword.into(),
+                    parsed,
+                    repeat_count,
+                ))
             })
             .collect::<Result<Vec<Section>, Error>>()?
     };
@@ -117,5 +186,53 @@ mod tests {
         assert_eq!(chord_parts[0].format(key, &rep), "G");
         assert_eq!(chord_parts[1].format(key, &rep), "C");
         assert_eq!(chord_parts[2].format(key, &rep), "D");
+    }
+
+    /// {repeat} and {repeat: N} on last line of section set section repeat_count.
+    /// See https://github.com/xilefmusics/chordlib/issues/10
+    #[test]
+    fn repeat_directive_last_line() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Chorus}
+[C][G][Am][F]
+{repeat}
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections.len(), 1);
+        assert_eq!(song.sections[0].repeat_count, 4, "{{repeat}} defaults to 4");
+        assert_eq!(song.sections[0].lines.len(), 1);
+
+        let input_n = r#"{title: Test}
+{key: C}
+{section: Verse}
+[G][C][D]
+{repeat: 2}
+"#;
+        let song_n = load_string(input_n).expect("parse");
+        assert_eq!(song_n.sections[0].repeat_count, 2);
+    }
+
+    #[test]
+    fn repeat_directive_not_last_rejected() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Verse}
+{repeat}
+[G][C]
+"#;
+        let r = load_string(input);
+        assert!(r.is_err(), "{{repeat}} not on last line must be rejected");
+    }
+
+    #[test]
+    fn no_repeat_default_one() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Verse}
+[G][C][D]
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections[0].repeat_count, 1);
     }
 }

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -9,7 +9,7 @@ use crate::error::Error;
 use crate::types::{Line, Part, Section, Song};
 
 /// If `line` is `{repeat}` or `{repeat: N}` (N ≥ 1), returns Some(repeat_count).
-/// `{repeat}` → 4. Otherwise returns None (not a repeat directive).
+/// `{repeat}` → 2. Otherwise returns None (not a repeat directive).
 /// Returns Err if it looks like a repeat directive but is invalid (e.g. `{repeat: 0}`).
 fn parse_repeat_directive(line: &str) -> Result<Option<u32>, Error> {
     let line = line.trim();
@@ -18,7 +18,8 @@ fn parse_repeat_directive(line: &str) -> Result<Option<u32>, Error> {
     }
     let inner = line[1..line.len() - 1].trim();
     if inner == "repeat" {
-        return Ok(Some(4));
+        // `{repeat}` means: play this section twice in total.
+        return Ok(Some(2));
     }
     if let Some(rest) = inner.strip_prefix("repeat:") {
         let n: u32 = rest
@@ -184,7 +185,7 @@ mod tests {
 "#;
         let song = load_string(input).expect("parse");
         assert_eq!(song.sections.len(), 1);
-        assert_eq!(song.sections[0].repeat_count, 4, "{{repeat}} defaults to 4");
+        assert_eq!(song.sections[0].repeat_count, 2, "{{repeat}} defaults to 2");
         assert_eq!(song.sections[0].lines.len(), 1);
 
         let input_n = r#"{title: Test}

--- a/src/outputs/html/render_section.rs
+++ b/src/outputs/html/render_section.rs
@@ -1,5 +1,5 @@
 use super::{render_bars, render_line};
-use crate::types::{ChordRepresentation, Line, Section, SimpleChord};
+use crate::types::{ChordRepresentation, Line, Part, Section, SimpleChord};
 
 fn is_chord_only_line(line: &Line) -> bool {
     line.parts
@@ -48,10 +48,97 @@ pub fn render_section(
         ));
     }
 
+    // Add a separate repeat line at the end of the section if needed.
+    if section.repeat_count > 1 {
+        let repeat_text = if section.repeat_count == 2 {
+            "(repeat)".to_string()
+        } else {
+            format!("(repeat {}x)", section.repeat_count)
+        };
+
+        // Ensure the languages vector has an entry for the requested language index.
+        let mut languages = vec![String::new(); language.saturating_add(1)];
+        languages[language] = repeat_text;
+
+        let repeat_line = Line {
+            parts: vec![Part {
+                chord: None,
+                languages,
+                comment: true,
+            }],
+        };
+
+        content.push_str(&render_line::render_line(
+            &repeat_line,
+            key,
+            representation,
+            language,
+        ));
+    }
+
     let title = section.title.to_uppercase();
 
     format!(
         "<p><span class=\"keyword\">{}</span><br>{}</p>",
         title, content
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{ChordRepresentation, Line, Part, Section, SimpleChord, Song};
+    use crate::outputs::FormatHTML;
+
+    fn make_song_with_section(title: &str, repeat_count: u32) -> Song {
+        let section = Section {
+            title: title.to_string(),
+            lines: vec![Line {
+                parts: vec![Part {
+                    chord: None,
+                    languages: vec!["Line".to_string()],
+                    comment: false,
+                }],
+            }],
+            repeat_count,
+        };
+
+        Song {
+            title: "Test".to_string(),
+            subtitle: None,
+            copyright: None,
+            key: Some(SimpleChord::default()),
+            artist: None,
+            language: None,
+            tempo: None,
+            time: None,
+            sections: vec![section],
+        }
+    }
+
+    #[test]
+    fn html_does_not_show_repeat_marker_for_default() {
+        let song = make_song_with_section("Chorus", 1);
+        let html = (&song).format_html(
+            None,
+            Some(&ChordRepresentation::Default),
+            None,
+            None,
+        );
+
+        assert!(html.contains("<span class=\"keyword\">CHORUS</span>"));
+        assert!(!html.contains("(repeat"));
+    }
+
+    #[test]
+    fn html_shows_repeat_marker_for_section_with_repeat_count() {
+        let song = make_song_with_section("Chorus", 2);
+        let html = (&song).format_html(
+            None,
+            Some(&ChordRepresentation::Default),
+            None,
+            None,
+        );
+
+        assert!(html.contains("<span class=\"comment\">(repeat)</span>"));
+    }
 }

--- a/src/types/section.rs
+++ b/src/types/section.rs
@@ -2,12 +2,16 @@ use serde::{Deserialize, Serialize};
 
 use super::{Line, SimpleChord};
 
+fn default_repeat_count() -> u32 {
+    1
+}
+
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Section {
     pub title: String,
     pub lines: Vec<Line>,
     /// How many times this section is repeated (from `{repeat}` or `{repeat: N}`). Default 1.
-    #[serde(default)]
+    #[serde(default = "default_repeat_count")]
     pub repeat_count: u32,
 }
 

--- a/src/types/section.rs
+++ b/src/types/section.rs
@@ -6,11 +6,26 @@ use super::{Line, SimpleChord};
 pub struct Section {
     pub title: String,
     pub lines: Vec<Line>,
+    /// How many times this section is repeated (from `{repeat}` or `{repeat: N}`). Default 1.
+    #[serde(default)]
+    pub repeat_count: u32,
 }
 
 impl Section {
     pub fn new(title: String, lines: Vec<Line>) -> Self {
-        Self { title, lines }
+        Self {
+            title,
+            lines,
+            repeat_count: 1,
+        }
+    }
+
+    pub fn new_with_repeat(title: String, lines: Vec<Line>, repeat_count: u32) -> Self {
+        Self {
+            title,
+            lines,
+            repeat_count: repeat_count.max(1),
+        }
     }
 
     pub fn normalize(&mut self, key: &SimpleChord) -> &mut Self {


### PR DESCRIPTION
## Context

Implements #10: ChordPro authors can add `{repeat}` or `{repeat: N}` at the **last line** of a section so the section has a repeat counter for rendering/playback.

## Changes

- **Section**: new field `repeat_count` (default 1), serialized with `#[serde(default)]` for backward compatibility.
- **Parsing**: A line that is exactly `{repeat}` or `{repeat: N}` (N ≥ 1) is accepted only when it is the last line of the section; it sets `repeat_count` (default 4 for `{repeat}`) and is not stored as content.
- **Reject**: If `{repeat}` or `{repeat: N}` appears on any other line, the parser returns an error.
- **Existing files**: Sections without the directive keep `repeat_count` 1.

## Testing

- `cargo test` (including `repeat_directive_last_line`, `repeat_directive_not_last_rejected`, `no_repeat_default_one`).
- `cargo fmt` and `cargo clippy --all-targets --all-features`.

Fixes #10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d330efa1f2343e50505f68c4cf2aa53d9317e8aa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->