### PR TITLE
Support ChordPro I/O with Nashville number notation for chords

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ chordlib path/to/song.cp \
 
 The CLI supports transposition (`--key`), Nashville notation (`--nashville`), vowel-based chord shifting (`--vowel-move`), and output formats including ChordPro (`.cp`/`.wp`), HTML, and JSON.
 
+ChordPro I/O supports **Nashville number notation** for chords: you can load files that use numbers (e.g. `[1][4][5]`, `[1m][4][5]`) when the key is set with a letter name (e.g. `{key: C}`). The `{key: …}` directive must be a letter name, not a number. Use the `--nashville` flag when writing ChordPro to output chords in Nashville form; the key is always written as a letter (e.g. `{key: C}`).
+
 To parse an Ultimate Guitar tab from HTML, first obtain the HTML (for example by saving the page in a browser), read it into a string, and then call `chordlib::inputs::ultimate_guitar::load_html(&html)` from your own code. The library no longer performs live HTTP requests to Ultimate Guitar.
 
 ## Feature flags

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -6,7 +6,7 @@ use iter_section::SectionIterator;
 use iter_space_section::SpaceSectionIterator;
 
 use crate::error::Error;
-use crate::types::{Line, Part, Section, Song};
+use crate::types::{Line, Part, Section, SimpleChord, Song};
 
 pub fn load(path: &str) -> Result<Song, Error> {
     load_string(&std::fs::read_to_string(path)?)
@@ -66,11 +66,26 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
             .collect::<Result<Vec<Section>, Error>>()?
     };
 
+    let key_str = key.ok_or(Error::Parse("no key given".into()))?;
+    let key_str = key_str.trim();
+    if key_str
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(true)
+    {
+        return Err(Error::Parse(
+            "key must be a letter name (e.g. C, G), not a Nashville number".into(),
+        ));
+    }
+    let key_simple: SimpleChord = key_str.try_into()?;
+
+    let title = title.ok_or(Error::Parse("no title given".into()))?;
     Ok(Song {
-        title: title.ok_or(Error::Parse("no title given".into()))?,
+        title,
         subtitle,
         copyright,
-        key: Some((key.ok_or(Error::Parse("no key given".into()))?.as_str()).try_into()?),
+        key: Some(key_simple),
         artist,
         language,
         tempo,
@@ -117,5 +132,48 @@ mod tests {
         assert_eq!(chord_parts[0].format(key, &rep), "G");
         assert_eq!(chord_parts[1].format(key, &rep), "C");
         assert_eq!(chord_parts[2].format(key, &rep), "D");
+    }
+
+    /// Nashville ChordPro: chords as numbers, key must be letter. Round-trip.
+    /// See https://github.com/xilefmusics/chordlib/issues/12
+    #[test]
+    fn nashville_chord_pro_roundtrip() {
+        let input = r#"{title: Nashville Test}
+{key: C}
+{section: Verse}
+[1][4][5][1]
+[1m][4][5]
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections.len(), 1);
+        let key = song.key.as_ref().unwrap();
+        let rep = ChordRepresentation::Nashville;
+        let line0: Vec<String> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .map(|c| c.format(key, &rep).to_string())
+            .collect();
+        assert_eq!(line0, ["1", "4", "5", "1"], "Nashville chords in key C");
+        use crate::outputs::FormatChordPro;
+        let out = (&song).format_chord_pro(None, Some(&rep), None, false);
+        assert!(
+            out.contains("{key:C}") || out.contains("{key: C}"),
+            "key stays letter in output"
+        );
+        assert!(out.contains("[1]") && out.contains("[4]") && out.contains("[5]"));
+        let again = load_string(&out).expect("round-trip");
+        assert_eq!(again.key, song.key);
+    }
+
+    #[test]
+    fn key_must_be_letter_rejects_nashville_number() {
+        let input = r#"{title: Test}
+{key: 1}
+{section: Verse}
+[ C]
+"#;
+        let r = load_string(input);
+        assert!(r.is_err(), "{{key: 1}} must be rejected");
     }
 }

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -211,7 +211,7 @@ mod tests {
     /// markers are stripped and only real chords (e.g. [G][C][D]) are parsed.
     /// See: https://github.com/xilefmusics/chordlib/issues/6
     #[test]
-     fn load_string_accepts_repeat_markers() {
+    fn load_string_accepts_repeat_markers() {
         let input = r#"{title: Test}
 {key: C}
 {section: Verse}
@@ -236,90 +236,90 @@ mod tests {
         );
         assert_eq!(chord_parts[0].format(key, &rep), "G");
         assert_eq!(chord_parts[1].format(key, &rep), "C");
-         assert_eq!(chord_parts[2].format(key, &rep), "D");
-     }
+        assert_eq!(chord_parts[2].format(key, &rep), "D");
+    }
 
-     /// Nashville ChordPro: chords as numbers, key must be letter. Round-trip.
-     /// See https://github.com/xilefmusics/chordlib/issues/12
-     #[test]
-     fn nashville_chord_pro_roundtrip() {
-         let input = r#"{title: Nashville Test}
- {key: C}
- {section: Verse}
- [1][4][5][1]
- [1m][4][5]
- "#;
-         let song = load_string(input).expect("parse");
-         assert_eq!(song.sections.len(), 1);
-         let key = song.key.as_ref().unwrap();
-         let rep = ChordRepresentation::Nashville;
-         let line0: Vec<String> = song.sections[0].lines[0]
-             .parts
-             .iter()
-             .filter_map(|p| p.chord.as_ref())
-             .map(|c| c.format(key, &rep).to_string())
-             .collect();
-         assert_eq!(line0, ["1", "4", "5", "1"], "Nashville chords in key C");
-         use crate::outputs::FormatChordPro;
-         let out = (&song).format_chord_pro(None, Some(&rep), None, false);
-         assert!(
-             out.contains("{key:C}") || out.contains("{key: C}"),
-             "key stays letter in output"
-         );
-         assert!(out.contains("[1]") && out.contains("[4]") && out.contains("[5]"));
-         let again = load_string(&out).expect("round-trip");
-         assert_eq!(again.key, song.key);
-     }
+    /// Nashville ChordPro: chords as numbers, key must be letter. Round-trip.
+    /// See https://github.com/xilefmusics/chordlib/issues/12
+    #[test]
+    fn nashville_chord_pro_roundtrip() {
+        let input = r#"{title: Nashville Test}
+{key: C}
+{section: Verse}
+[1][4][5][1]
+[1m][4][5]
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections.len(), 1);
+        let key = song.key.as_ref().unwrap();
+        let rep = ChordRepresentation::Nashville;
+        let line0: Vec<String> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .map(|c| c.format(key, &rep).to_string())
+            .collect();
+        assert_eq!(line0, ["1", "4", "5", "1"], "Nashville chords in key C");
+        use crate::outputs::FormatChordPro;
+        let out = (&song).format_chord_pro(None, Some(&rep), None, false);
+        assert!(
+            out.contains("{key:C}") || out.contains("{key: C}"),
+            "key stays letter in output"
+        );
+        assert!(out.contains("[1]") && out.contains("[4]") && out.contains("[5]"));
+        let again = load_string(&out).expect("round-trip");
+        assert_eq!(again.key, song.key);
+    }
 
-     #[test]
-     fn key_must_be_letter_rejects_nashville_number() {
-         let input = r#"{title: Test}
- {key: 1}
- {section: Verse}
- [ C]
- "#;
-         let r = load_string(input);
-         assert!(r.is_err(), "{{key: 1}} must be rejected");
-     }
+    #[test]
+    fn key_must_be_letter_rejects_nashville_number() {
+        let input = r#"{title: Test}
+{key: 1}
+{section: Verse}
+[ C]
+"#;
+        let r = load_string(input);
+        assert!(r.is_err(), "{{key: 1}} must be rejected");
+    }
 
-     /// Worship Pro duration: parse clicks (decimal) as milliclicks; round-trip.
-     /// See https://github.com/xilefmusics/chordlib/issues/9
-     #[test]
-     fn worship_pro_duration_roundtrip() {
-         let input = r#"{title: Durations}
- {key: C}
- {section: Verse}
- [C:4][Am:1.5][G:2][F:1]
- "#;
-         let song = load_string(input).expect("parse");
-         assert_eq!(song.sections.len(), 1);
-         let parts: Vec<_> = song.sections[0].lines[0]
-             .parts
-             .iter()
-             .filter_map(|p| p.chord.as_ref())
-             .collect();
-         assert_eq!(parts.len(), 4);
-         assert_eq!(parts[0].get_duration(), Some(4000));
-         assert_eq!(parts[1].get_duration(), Some(1500));
-         assert_eq!(parts[2].get_duration(), Some(2000));
-         assert_eq!(parts[3].get_duration(), Some(1000));
+    /// Worship Pro duration: parse clicks (decimal) as milliclicks; round-trip.
+    /// See https://github.com/xilefmusics/chordlib/issues/9
+    #[test]
+    fn worship_pro_duration_roundtrip() {
+        let input = r#"{title: Durations}
+{key: C}
+{section: Verse}
+[C:4][Am:1.5][G:2][F:1]
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections.len(), 1);
+        let parts: Vec<_> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0].get_duration(), Some(4000));
+        assert_eq!(parts[1].get_duration(), Some(1500));
+        assert_eq!(parts[2].get_duration(), Some(2000));
+        assert_eq!(parts[3].get_duration(), Some(1000));
 
-         use crate::outputs::FormatChordPro;
-         let out = (&song).format_chord_pro(
-             None,
-             Some(&ChordRepresentation::Default),
-             None,
-             true, // worship_pro
-         );
-         assert!(out.contains("[C:4]"), "integer clicks");
-         assert!(out.contains("[Am:1.5]"), "decimal clicks");
-         let again = load_string(&out).expect("round-trip parse");
-         let again_parts: Vec<_> = again.sections[0].lines[0]
-             .parts
-             .iter()
-             .filter_map(|p| p.chord.as_ref())
-             .collect();
-         assert_eq!(again_parts[0].get_duration(), Some(4000));
-         assert_eq!(again_parts[1].get_duration(), Some(1500));
-     }
+        use crate::outputs::FormatChordPro;
+        let out = (&song).format_chord_pro(
+            None,
+            Some(&ChordRepresentation::Default),
+            None,
+            true, // worship_pro
+        );
+        assert!(out.contains("[C:4]"), "integer clicks");
+        assert!(out.contains("[Am:1.5]"), "decimal clicks");
+        let again = load_string(&out).expect("round-trip parse");
+        let again_parts: Vec<_> = again.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(again_parts[0].get_duration(), Some(4000));
+        assert_eq!(again_parts[1].get_duration(), Some(1500));
+    }
 }

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -67,7 +67,9 @@ impl SimpleChord {
 
     pub fn format(&self, key: &SimpleChord, representation: &ChordRepresentation) -> &'static str {
         match representation {
-            ChordRepresentation::Nashville => CHORD_STRINGS_NASHVILLE[self.level as usize],
+            ChordRepresentation::Nashville => {
+                CHORD_STRINGS_NASHVILLE[((self.level + key.level) % 12) as usize]
+            }
             ChordRepresentation::Default => match key.level {
                 0 | 2 | 3 | 5 | 7 | 9 | 10 => {
                     CHORD_STRINGS_SHARP[((self.level + key.level) % 12) as usize]


### PR DESCRIPTION
## Context

Implements #12: ChordPro files can use Nashville numbers for chords; key must stay letter-based.

## Changes

- **Key validation**: Reject `{key: 1}` (or any key starting with a digit); key must be a letter name (e.g. C, G).
- **Nashville output**: SimpleChord format for Nashville now uses `(level + key.level) % 12` so normalized chords display as the correct scale degree (1, 4, 5, etc.).
- **README**: Document that ChordPro I/O supports Nashville for chords, key remains letter-based, and how to use `--nashville`.
- **Tests**: `nashville_chord_pro_roundtrip`, `key_must_be_letter_rejects_nashville_number`.

## Testing

- `cargo test`, `cargo fmt`, `cargo clippy --all-targets --all-features`.

Fixes #12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 4cde6676335ae6feb74cecaab3bd1bf8958fdbc7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->