### PR TITLE
Improve bar positioning for chord-only lines: show beat slashes

### DIFF
--- a/src/outputs/html/render_bars.rs
+++ b/src/outputs/html/render_bars.rs
@@ -1,21 +1,79 @@
 use crate::types::{ChordRepresentation, Line, SimpleChord};
 
+/// One symbol per beat:
+/// - chord name when a chord starts on that beat,
+/// - "/" when continuing the same chord for a full beat,
+/// - "·" when continuing the same chord for a shorter (fractional) beat.
+fn format_bar_beat_slashes(bar: &[(String, u32)], bar_duration: u32, beats_per_bar: u32) -> String {
+    if beats_per_bar == 0 {
+        return String::new();
+    }
+    let mut symbols = Vec::with_capacity(beats_per_bar as usize);
+    let beat_duration = if beats_per_bar > 0 {
+        bar_duration / beats_per_bar
+    } else {
+        0
+    };
+    let mut prev_chord_idx: Option<usize> = None;
+    for beat in 0..beats_per_bar {
+        let pos = beat * bar_duration / beats_per_bar;
+        let mut seg_start = 0u32;
+        let mut chord_idx: Option<usize> = None;
+        let mut seg_end = 0u32;
+
+        for (idx, (_chord_str, dur)) in bar.iter().enumerate() {
+            seg_end = seg_start + *dur;
+            if pos < seg_end {
+                chord_idx = Some(idx);
+                break;
+            }
+            seg_start = seg_end;
+        }
+
+        let symbol = match (chord_idx, prev_chord_idx) {
+            // No chord covers this beat position.
+            (None, _) => "·".to_string(),
+            // Same chord as on the previous beat → continuation:
+            // "/" if at least a full beat of this chord remains, otherwise "·".
+            (Some(idx), Some(prev)) if idx == prev => {
+                let remaining = seg_end.saturating_sub(pos);
+                if beat_duration > 0 && remaining >= beat_duration {
+                    "/".to_string()
+                } else {
+                    "·".to_string()
+                }
+            }
+            // First sampled beat within this chord's span → show the chord name.
+            (Some(idx), _) => {
+                prev_chord_idx = Some(idx);
+                bar[idx].0.clone()
+            }
+        };
+
+        symbols.push(symbol);
+    }
+    symbols.join(" ")
+}
+
 pub fn render_bars(
     lines: &[&Line],
     key: &SimpleChord,
     representation: &ChordRepresentation,
     bar_duration: u32,
+    beats_per_bar: u32,
 ) -> String {
     let mut columns: Vec<String> = Vec::new();
+    let beats_per_bar = beats_per_bar.max(1);
+
     for line in lines {
         let mut bars = vec![];
-        let mut current_bar = vec![];
-        let mut duration_buffer = 0;
+        let mut current_bar: Vec<(String, u32)> = vec![];
+        let mut duration_buffer = 0u32;
 
         for (chord_str, duration) in line.parts.iter().filter_map(|part| {
             part.chord.as_ref().map(|chord| {
                 (
-                    chord.format(key, representation),
+                    chord.format(key, representation).to_string(),
                     chord.get_duration().unwrap_or(bar_duration),
                 )
             })
@@ -40,11 +98,7 @@ pub fn render_bars(
         }
 
         for (idx, bar) in bars.into_iter().enumerate() {
-            let formatted_bar = bar
-                .into_iter()
-                .map(|(chord, _)| chord)
-                .collect::<Vec<_>>()
-                .join(" ");
+            let formatted_bar = format_bar_beat_slashes(&bar, bar_duration, beats_per_bar);
 
             match columns.get_mut(idx) {
                 Some(column) => {
@@ -76,3 +130,108 @@ pub fn render_bars(
 
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Chord, Part};
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
+    fn line_with_chords(specs: &[&str]) -> Line {
+        let parts: Vec<Part> = specs
+            .iter()
+            .map(|s| Part::new_chord(Chord::from_str(s).unwrap()))
+            .collect();
+        Line { parts }
+    }
+
+    /// Chords whose durations are fractional beats (e.g. 1.5 + 2.5 beats)
+    /// must still show *both* chord names somewhere in the bar grid.
+    #[test]
+    fn bars_show_chords_starting_on_fractional_beats() {
+        // 4/4 time → 4 beats, 4000 milliclicks per bar.
+        let bar_duration = 4000;
+        let beats_per_bar = 4;
+
+        // First chord: C for 1.5 beats (1500 milliclicks),
+        // second chord: G for 2.5 beats (2500 milliclicks).
+        // Together they fill exactly one bar.
+        let line = line_with_chords(&["C:1.5", "G:2.5"]);
+
+        // Use a concrete key / representation, matching other tests in this crate.
+        let key: SimpleChord = "C".try_into().unwrap();
+        let rep = ChordRepresentation::Default;
+
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+
+        // Extract the rendered chord symbols for the (single) bar.
+        let chord_span_start = html
+            .find("<span class=\"chord\">")
+            .expect("chord span start not found");
+        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
+        let chord_span_end = html[chord_span_start..]
+            .find("</span>")
+            .expect("chord span end not found")
+            + chord_span_start;
+        let chord_text = &html[chord_span_start..chord_span_end];
+
+        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
+        assert_eq!(
+            tokens.len(),
+            beats_per_bar as usize,
+            "expected one symbol per beat; got: {chord_text}"
+        );
+
+        let unique_chords: HashSet<&str> = tokens
+            .iter()
+            .copied()
+            .filter(|t| *t != "·" && *t != "/")
+            .collect();
+        assert_eq!(
+            unique_chords.len(),
+            2,
+            "fractional-beat chords must both appear somewhere in the bar grid; got: {chord_text}"
+        );
+    }
+
+    /// Regression-style test with another pair of chords whose split point does
+    /// not coincide with integer beat positions, to ensure later chords are not
+    /// silently dropped.
+    #[test]
+    fn bars_do_not_drop_late_fractional_chord() {
+        let bar_duration = 4000;
+        let beats_per_bar = 4;
+
+        // Two chords that together fill the bar, with the *second* starting on a
+        // non-integer beat. Any reasonable rendering should show both "D" and "E".
+        let line = line_with_chords(&["D:1.5", "E:2.5"]);
+
+        let key: SimpleChord = "D".try_into().unwrap();
+        let rep = ChordRepresentation::Default;
+
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+
+        let chord_span_start = html
+            .find("<span class=\"chord\">")
+            .expect("chord span start not found");
+        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
+        let chord_span_end = html[chord_span_start..]
+            .find("</span>")
+            .expect("chord span end not found")
+            + chord_span_start;
+        let chord_text = &html[chord_span_start..chord_span_end];
+
+        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
+        let unique_chords: HashSet<&str> = tokens
+            .iter()
+            .copied()
+            .filter(|t| *t != "·" && *t != "/")
+            .collect();
+        assert!(
+            unique_chords.len() >= 2,
+            "bar rendering must not drop later fractional chords; got: {chord_text}"
+        );
+    }
+}
+

--- a/src/outputs/html/render_section.rs
+++ b/src/outputs/html/render_section.rs
@@ -13,6 +13,7 @@ pub fn render_section(
     representation: &ChordRepresentation,
     language: usize,
     bar_duration: u32,
+    beats_per_bar: u32,
 ) -> String {
     let mut content = String::new();
     let mut chord_only_line_buffer = Vec::new();
@@ -27,6 +28,7 @@ pub fn render_section(
                     key,
                     representation,
                     bar_duration,
+                    beats_per_bar,
                 ));
                 chord_only_line_buffer.clear();
             }
@@ -45,6 +47,7 @@ pub fn render_section(
             key,
             representation,
             bar_duration,
+            beats_per_bar,
         ));
     }
 

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -31,6 +31,7 @@ impl FormatHTML for &Song {
             (None, None) => String::new(),
         };
 
+        let beats_per_bar = self.time.map(|(n, _)| n).unwrap_or(4);
         let page_template = self
             .sections
             .iter()
@@ -43,6 +44,7 @@ impl FormatHTML for &Song {
                         .unwrap_or(&&ChordRepresentation::Default),
                     language,
                     self.bar_duration(),
+                    beats_per_bar,
                 )
             })
             .fold(


### PR DESCRIPTION
## Context

Implements #11: chord-only lines rendered with bar lines now show one symbol per beat—chord name when a chord starts, `/` when the previous chord is still in effect.

## Changes

- **render_bars**: New parameter `beats_per_bar` (from song time sig, default 4). Each bar is formatted with one symbol per beat via `format_bar_beat_slashes`: chord name on the beat where the chord starts, `/` on following beats until the next chord.
- **render_section**: Passes `beats_per_bar` (from song) into `render_bars`.
- **render_song**: Computes `beats_per_bar` from `self.time` (numerator) or 4.

## Testing

- `cargo test`, `cargo fmt`, `cargo clippy --all-targets --all-features`.

Fixes #11