### PR TITLE
fix(worship-pro): preserve repeat directives on export (#22)

### DIFF
--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -207,6 +207,42 @@ mod tests {
         assert_eq!(song.sections[0].repeat_count, 1);
     }
 
+    /// Worship Pro export keeps {repeat} / {repeat: N}; ChordPro export uses {comment: (repeat)}.
+    #[test]
+    fn repeat_export_worship_pro_and_chord_pro() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Chorus}
+[C][G][Am][F]
+{repeat}
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections[0].repeat_count, 2);
+
+        use crate::outputs::FormatChordPro;
+        let wp = (&song).format_chord_pro(None, None, None, true);
+        assert!(wp.contains("{repeat}"), "Worship Pro export must contain {{repeat}}");
+
+        let cp = (&song).format_chord_pro(None, None, None, false);
+        assert!(
+            cp.contains("{comment: (repeat)}"),
+            "ChordPro export must contain {{comment: (repeat)}}"
+        );
+
+        let input_n = r#"{title: Test}
+{key: C}
+{section: Verse}
+[G][C][D]
+{repeat: 3}
+"#;
+        let song_n = load_string(input_n).expect("parse");
+        assert_eq!(song_n.sections[0].repeat_count, 3);
+        let wp_n = (&song_n).format_chord_pro(None, None, None, true);
+        assert!(wp_n.contains("{repeat: 3}"));
+        let cp_n = (&song_n).format_chord_pro(None, None, None, false);
+        assert!(cp_n.contains("{comment: (repeat 3x)}"));
+    }
+
     /// ChordPro with CCLI-style repeat markers [||:] and [:||] must import without error;
     /// markers are stripped and only real chords (e.g. [G][C][D]) are parsed.
     /// See: https://github.com/xilefmusics/chordlib/issues/6

--- a/src/outputs/chord_pro/render_section.rs
+++ b/src/outputs/chord_pro/render_section.rs
@@ -16,8 +16,10 @@ pub fn render_section(
         format!("\n{}:", section.title)
     };
 
-    std::iter::once(keyword)
-        .chain(section.lines.iter().map(|line| {
+    let line_outputs: Vec<String> = section
+        .lines
+        .iter()
+        .map(|line| {
             render_line(
                 line,
                 key,
@@ -26,7 +28,30 @@ pub fn render_section(
                 worship_pro_features,
                 bar_duration,
             )
-        }))
+        })
+        .collect();
+
+    let repeat_line = if section.repeat_count > 1 {
+        Some(if worship_pro_features {
+            if section.repeat_count == 2 {
+                "{repeat}".to_string()
+            } else {
+                format!("{{repeat: {}}}", section.repeat_count)
+            }
+        } else {
+            if section.repeat_count == 2 {
+                "{comment: (repeat)}".to_string()
+            } else {
+                format!("{{comment: (repeat {}x)}}", section.repeat_count)
+            }
+        })
+    } else {
+        None
+    };
+
+    std::iter::once(keyword)
+        .chain(line_outputs.into_iter())
+        .chain(repeat_line.into_iter())
         .collect::<Vec<String>>()
         .join("\n")
 }


### PR DESCRIPTION
Ensure Worship Pro exports keep {repeat} directives and map to appropriate ChordPro comments so repeats are preserved end-to-end.

Made-with: Cursor