### PR TITLE
fix(chords): derive slash bass spelling from interval and key

### DIFF
--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -298,6 +298,41 @@ mod tests {
         assert_eq!(song.sections[0].repeat_count, 1);
     }
 
+    #[test]
+    fn chordpro_preserves_enharmonic_slash_bass() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Verse}
+[G#/B#]Lyric
+"#;
+        let song = load_string(input).expect("parse");
+        use crate::outputs::FormatChordPro;
+        let out = (&song).format_chord_pro(None, Some(&ChordRepresentation::Default), None, false);
+        assert!(
+            out.contains("[G#/B#]"),
+            "expected G#/B# in export, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn chordpro_parse_line_with_many_slash_chords() {
+        let input = r#"{title: Slash line}
+{key: C}
+{section: Verse}
+[C/G][D/F#][G/B][Am/E][F/Cb][E/G][Bb/D]Lyrics here
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections.len(), 1);
+        assert_eq!(song.sections[0].lines.len(), 1);
+        assert_eq!(song.sections[0].lines[0].parts.len(), 7);
+        use crate::outputs::FormatChordPro;
+        let out = (&song).format_chord_pro(None, Some(&ChordRepresentation::Default), None, false);
+        assert!(
+            out.contains("Verse") && out.contains("Lyrics here"),
+            "unexpected export:\n{out}"
+        );
+    }
+
     /// Worship Pro export keeps {repeat} / {repeat: N}; ChordPro export uses {comment: (repeat)}.
     #[test]
     fn repeat_export_worship_pro_and_chord_pro() {

--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -1,8 +1,123 @@
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+use super::chord_simple::{CHORD_STRINGS_ENHARMONIC, CHORD_STRINGS_FLAT, CHORD_STRINGS_SHARP};
 use super::{ChordRepresentation, SimpleChord};
 use crate::error::Error;
+
+const DIATONIC_LETTERS: &str = "CDEFGAB";
+
+fn letter_natural_pc(c: char) -> Option<u8> {
+    match c {
+        'A' => Some(0),
+        'B' => Some(2),
+        'C' => Some(3),
+        'D' => Some(5),
+        'E' => Some(7),
+        'F' => Some(8),
+        'G' => Some(10),
+        _ => None,
+    }
+}
+
+fn advance_diatonic_letter(root: char, steps: usize) -> Option<char> {
+    let i = DIATONIC_LETTERS.find(root)?;
+    Some(DIATONIC_LETTERS.as_bytes()[(i + steps) % 7] as char)
+}
+
+fn parse_root_nominal_letter(root_display: &str, expect_m_abs: u8) -> Option<char> {
+    let mut cs = root_display.chars();
+    let letter = cs.next()?;
+    if !matches!(letter, 'A'..='G') {
+        return None;
+    }
+    let nat = letter_natural_pc(letter)?;
+    let acc: i16 = cs.fold(0i16, |a, ch| match ch {
+        '#' => a + 1,
+        'b' => a - 1,
+        _ => a,
+    });
+    let pc = (nat as i16 + acc).rem_euclid(12) as u8;
+    if pc != expect_m_abs {
+        return None;
+    }
+    Some(letter)
+}
+
+fn spell_letter_to_pc(letter: char, target_pc: u8) -> Option<&'static str> {
+    for &name in CHORD_STRINGS_SHARP
+        .iter()
+        .chain(CHORD_STRINGS_FLAT.iter())
+        .chain(CHORD_STRINGS_ENHARMONIC.iter())
+    {
+        if !name.starts_with(letter) {
+            continue;
+        }
+        let Ok(sc) = SimpleChord::try_from(name) else {
+            continue;
+        };
+        if sc.pitch_class() == target_pc {
+            return Some(name);
+        }
+    }
+    None
+}
+
+fn spell_slash_bass_from_intervals(
+    root_letter: char,
+    _m_abs: u8,
+    b_abs: u8,
+    interval: u8,
+) -> Option<&'static str> {
+    match interval {
+        0 => spell_letter_to_pc(root_letter, b_abs),
+        1 | 2 => {
+            let t = advance_diatonic_letter(root_letter, 1)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        3 | 4 => {
+            let t = advance_diatonic_letter(root_letter, 2)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        5 => {
+            let t = advance_diatonic_letter(root_letter, 3)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        6 => {
+            let fifth = advance_diatonic_letter(root_letter, 4)?;
+            if let Some(s) = spell_letter_to_pc(fifth, b_abs) {
+                return Some(s);
+            }
+            let fourth = advance_diatonic_letter(root_letter, 3)?;
+            spell_letter_to_pc(fourth, b_abs)
+        }
+        7 => {
+            let t = advance_diatonic_letter(root_letter, 4)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        8..=11 => {
+            let t = advance_diatonic_letter(root_letter, 5)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        _ => None,
+    }
+}
+
+fn format_slash_bass_default(
+    main: &SimpleChord,
+    base: &SimpleChord,
+    key: &SimpleChord,
+) -> &'static str {
+    let m_abs = main.combined_level(key);
+    let b_abs = base.combined_level(key);
+    let interval = (b_abs + 12 - m_abs) % 12;
+    let root_display = SimpleChord::root_display_name(m_abs, key);
+    let Some(root_letter) = parse_root_nominal_letter(root_display, m_abs) else {
+        return base.format(key, &ChordRepresentation::Default);
+    };
+    spell_slash_bass_from_intervals(root_letter, m_abs, b_abs, interval)
+        .unwrap_or_else(|| base.format(key, &ChordRepresentation::Default))
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub enum Kind {
@@ -121,15 +236,20 @@ impl Chord {
     pub fn format(&self, key: &SimpleChord, representation: &ChordRepresentation) -> String {
         let (optional_start, optional_end) = if self.optional { ("(", ")") } else { ("", "") };
 
+        let slash = self.base.as_ref().map(|base| {
+            let bass = match representation {
+                ChordRepresentation::Default => format_slash_bass_default(&self.main, base, key),
+                _ => base.format(key, representation),
+            };
+            format!("/{bass}")
+        });
+
         format!(
             "{}{}{}{}{}{}",
             optional_start,
             self.main.format(key, representation),
             self.kind.format(),
-            self.base
-                .clone()
-                .map(|base| format!("/{}", base.format(key, representation)))
-                .unwrap_or_default(),
+            slash.unwrap_or_default(),
             self.var,
             optional_end,
         )
@@ -186,11 +306,17 @@ impl Chord {
         (Kind::Major, s)
     }
 
-    fn parse_base(s: &str) -> Result<(Option<SimpleChord>, &str), Error> {
+    fn parse_slash_bass(s: &str) -> Result<Option<SimpleChord>, Error> {
         if s.is_empty() {
-            return Ok((None, s));
+            return Ok(None);
         }
-        Self::parse_simple_chord(s).map(|(chord, s)| (Some(chord), s))
+        let (chord, rest) = Self::parse_simple_chord(s)?;
+        if !rest.is_empty() {
+            return Err(Error::Parse(format!(
+                "invalid characters after bass note: {rest}",
+            )));
+        }
+        Ok(Some(chord))
     }
 
     fn parse_var(s: &str) -> (&str, &str) {
@@ -227,7 +353,7 @@ impl FromStr for Chord {
         let (main, s) = Self::parse_simple_chord(s)?;
         let (kind, s) = Self::parse_kind(s);
         let (var, s) = Self::parse_var(s);
-        let (base, _) = Self::parse_base(s)?;
+        let base = Self::parse_slash_bass(s)?;
 
         Ok(Self {
             main,
@@ -243,6 +369,29 @@ impl FromStr for Chord {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::types::ChordRepresentation;
+
+    fn fmt_default(sym: &str, key: &SimpleChord) -> String {
+        Chord::from_str(sym)
+            .unwrap_or_else(|e| panic!("parse {sym:?}: {e}"))
+            .format(key, &ChordRepresentation::Default)
+    }
+
+    fn fmt_nashville(sym: &str, key: &SimpleChord) -> String {
+        Chord::from_str(sym)
+            .unwrap()
+            .format(key, &ChordRepresentation::Nashville)
+    }
+
+    fn assert_default(sym: &str, key: &SimpleChord, want: &str) {
+        let got = fmt_default(sym, key);
+        assert_eq!(
+            got,
+            want,
+            "from_str({sym:?}) with key level {}",
+            key.pitch_class()
+        );
+    }
 
     #[test]
     fn chord_from_str() {
@@ -296,5 +445,258 @@ mod test {
 
         let g_2_25 = Chord::from_str("G:2.25").unwrap();
         assert_eq!(g_2_25.get_duration(), Some(2250));
+    }
+
+    #[test]
+    fn slash_bass_enharmonics_parse_and_format() {
+        let c = Chord::from_str("G#/B#").unwrap();
+        let key = SimpleChord::default();
+        assert_eq!(
+            c.format(&key, &ChordRepresentation::Default),
+            "G#/B#",
+            "default notation preserves written B# bass"
+        );
+        assert_eq!(
+            c.format(&key, &ChordRepresentation::Nashville),
+            "7/b3",
+            "Nashville uses scale-degree names (not letter bass spellings)"
+        );
+    }
+
+    #[test]
+    fn slash_bass_enharmonics_after_normalize_match_key_c() {
+        let c = Chord::from_str("G#/B#").unwrap();
+        let key = SimpleChord::try_from("C").unwrap();
+        let normalized = c.normalize(&key);
+        assert_eq!(
+            normalized.format(&key, &ChordRepresentation::Default),
+            "G#/B#"
+        );
+    }
+
+    #[test]
+    fn slash_bass_trailing_garbage_is_error() {
+        let err = Chord::from_str("C/Gx").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid characters after bass"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn slash_bass_diminished_fifth_and_major_sixth_spelling() {
+        let key = SimpleChord::default();
+        assert_eq!(
+            Chord::from_str("F/Cb")
+                .unwrap()
+                .format(&key, &ChordRepresentation::Default),
+            "F/Cb",
+            "tritone bass: lowered fifth letter (C→Cb)"
+        );
+        assert_eq!(
+            Chord::from_str("Ab/C")
+                .unwrap()
+                .format(&key, &ChordRepresentation::Default),
+            "G#/B#",
+            "same pitch class as Ab/C; key C uses sharp root name so the third is B#"
+        );
+        assert_eq!(
+            Chord::from_str("G/Fb")
+                .unwrap()
+                .format(&key, &ChordRepresentation::Default),
+            "G/E",
+            "Fb and E share pitch class; sixth is spelled with the diatonic letter E"
+        );
+    }
+
+    /// `SimpleChord::default()` is level 0 (A in internal encoding). Sharp key branch; combined
+    /// roots match treating the song key as A for these assertions.
+    #[test]
+    fn slash_bass_default_key_c_major_chords() {
+        let key = SimpleChord::default();
+        for (sym, want) in [
+            ("C/D", "C/D"),
+            ("C/E", "C/E"),
+            ("C/F", "C/F"),
+            ("C/G", "C/G"),
+            ("C/A", "C/A"),
+            ("C/B", "C/B"),
+            ("D/E", "D/E"),
+            ("D/F#", "D/F#"),
+            ("D/G", "D/G"),
+            ("D/A", "D/A"),
+            ("D/B", "D/B"),
+            ("E/F#", "E/F#"),
+            ("E/G#", "E/G#"),
+            ("E/A", "E/A"),
+            ("E/B", "E/B"),
+            ("F/G", "F/G"),
+            ("F/A", "F/A"),
+            ("F/B", "F/Cb"),
+            ("F/C", "F/C"),
+            ("G/A", "G/A"),
+            ("G/B", "G/B"),
+            ("G/C", "G/C"),
+            ("G/D", "G/D"),
+            ("G/F", "G/E#"),
+            ("A/B", "A/B"),
+            ("A/C#", "A/C#"),
+            ("A/D", "A/D"),
+            ("A/E", "A/E"),
+            ("B/C#", "B/C#"),
+            ("B/D#", "B/D#"),
+            ("B/E", "B/E"),
+            ("B/F#", "B/F#"),
+            ("C#/E#", "C#/E#"),
+            ("C#/F#", "C#/F#"),
+            ("C#/G#", "C#/G#"),
+            ("F#/A#", "F#/A#"),
+            ("F#/B", "F#/B"),
+            ("G#/C", "G#/B#"),
+            ("G#/D#", "G#/D#"),
+            ("Bb/D", "A#/D"),
+            ("Db/F", "C#/E#"),
+            ("Eb/G", "D#/G"),
+        ] {
+            assert_default(sym, &key, want);
+        }
+    }
+
+    /// ChordPro `{key: C}` uses `SimpleChord` level 3; slash spelling uses combined pitch + key.
+    #[test]
+    fn slash_bass_song_key_c_try_from_c() {
+        let key = SimpleChord::try_from("C").unwrap();
+        assert_eq!(key.pitch_class(), 3);
+        for (sym, want) in [("C/G", "D#/A#"), ("G/C", "A#/D#"), ("D/A", "F/C")] {
+            assert_default(sym, &key, want);
+        }
+    }
+
+    #[test]
+    fn slash_bass_default_key_c_minor_sus_dim_aug() {
+        let key = SimpleChord::default();
+        for (sym, want) in [
+            ("Am/C", "Am/C"),
+            ("Am/E", "Am/E"),
+            ("Am/G", "Am/G"),
+            ("Dm/F", "Dm/F"),
+            ("Dm/A", "Dm/A"),
+            ("Em/G", "Em/G"),
+            ("Em/B", "Em/B"),
+            ("Fm/Ab", "Fm/Ab"),
+            ("Gm/Bb", "Gm/Bb"),
+            ("Asus4/D", "Asus4/D"),
+            ("Asus4/E", "Asus4/E"),
+            ("Asus2/E", "Asus2/E"),
+            ("Dsus4/G", "Dsus4/G"),
+            ("Cdim/Gb", "Cdim/Gb"),
+            ("Caug/G#", "Caug/Ab"),
+            ("Daug/A#", "Daug/Bb"),
+        ] {
+            assert_default(sym, &key, want);
+        }
+    }
+
+    #[test]
+    fn slash_bass_default_flat_key_f() {
+        let key = SimpleChord::try_from("F").unwrap();
+        for (sym, want) in [
+            ("C/E", "Ab/C"),
+            ("F/C", "Db/Ab"),
+            ("Bb/F", "Gb/Db"),
+            ("Dm/G", "Bbm/Eb"),
+        ] {
+            assert_default(sym, &key, want);
+        }
+    }
+
+    #[test]
+    fn slash_bass_default_flat_key_db() {
+        let key = SimpleChord::try_from("Db").unwrap();
+        for (sym, want) in [("Db/F", "F/A"), ("Ab/Eb", "C/G"), ("Eb/G", "G/B")] {
+            assert_default(sym, &key, want);
+        }
+    }
+
+    #[test]
+    fn slash_bass_nashville_key_c_table() {
+        let key = SimpleChord::default();
+        for (sym, want) in [
+            ("C/G", "b3/b7"),
+            ("D/F#", "4/6"),
+            ("G/B", "b7/2"),
+            ("Am/C", "1m/b3"),
+            ("G#/B#", "7/b3"),
+            ("F/Cb", "b6/2"),
+        ] {
+            assert_eq!(fmt_nashville(sym, &key), want, "{sym}");
+        }
+    }
+
+    #[test]
+    fn slash_bass_optional_parens_and_duration() {
+        let key = SimpleChord::default();
+        assert_eq!(
+            Chord::from_str("(C/G)")
+                .unwrap()
+                .format(&key, &ChordRepresentation::Default),
+            "(C/G)"
+        );
+        let with_dur = Chord::from_str("C/G:2").unwrap();
+        assert_eq!(with_dur.get_duration(), Some(2000));
+        assert_eq!(
+            with_dur.format(&key, &ChordRepresentation::Default),
+            "C/G",
+            "Chord::format omits duration; Worship Pro layer adds it"
+        );
+        let am = Chord::from_str("Am/E:1.5").unwrap();
+        assert_eq!(am.get_duration(), Some(1500));
+        assert_eq!(am.format(&key, &ChordRepresentation::Default), "Am/E");
+    }
+
+    #[test]
+    fn slash_bass_parse_rejects_trailing_bass_junk() {
+        for bad in ["C/Gx", "D/F#z", "E/G#xy", "Am/Cq", "G/B#extra"] {
+            let err = Chord::from_str(bad).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid characters after bass"),
+                "{bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn slash_bass_transpose_then_format_key_c() {
+        let key = SimpleChord::default();
+        let c = Chord::from_str("C/G").unwrap().transpose(2);
+        assert_eq!(c.format(&key, &ChordRepresentation::Default), "D/A");
+        let g = Chord::from_str("G/B").unwrap().transpose(5);
+        assert_eq!(g.format(&key, &ChordRepresentation::Default), "C/E");
+    }
+
+    #[test]
+    fn slash_bass_double_normalize_idempotent_format() {
+        let key = SimpleChord::default();
+        let c = Chord::from_str("C/G").unwrap();
+        let once = c.normalize(&key);
+        let twice = once.clone().normalize(&key);
+        assert_eq!(
+            once.format(&key, &ChordRepresentation::Default),
+            twice.format(&key, &ChordRepresentation::Default)
+        );
+    }
+
+    #[test]
+    fn chord_serde_json_roundtrip_slash_chords() {
+        let key = SimpleChord::default();
+        for sym in ["C/G", "G#/B#", "Am/C", "F/Cb", "Asus4/D"] {
+            let c = Chord::from_str(sym).unwrap();
+            let json = serde_json::to_string(&c).unwrap();
+            let back: Chord = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back.format(&key, &ChordRepresentation::Default),
+                fmt_default(sym, &key)
+            );
+        }
     }
 }

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -2,16 +2,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 
-static CHORD_STRINGS_SHARP: &[&str] = &[
+pub(crate) static CHORD_STRINGS_SHARP: &[&str] = &[
     "A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#",
 ];
-static CHORD_STRINGS_FLAT: &[&str] = &[
+pub(crate) static CHORD_STRINGS_FLAT: &[&str] = &[
     "A", "Bb", "B", "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab",
 ];
 
 static CHORD_STRINGS_NASHVILLE: &[&str] = &[
     "1", "b2", "2", "b3", "3", "4", "b5", "5", "b6", "6", "b7", "7",
 ];
+
+pub(crate) static CHORD_STRINGS_ENHARMONIC: &[&str] = &["B#", "E#", "Cb", "Fb"];
+pub(crate) static CHORD_LEVELS_ENHARMONIC: &[u8] = &[3, 8, 2, 7];
+
+const _: () = assert!(CHORD_STRINGS_ENHARMONIC.len() == CHORD_LEVELS_ENHARMONIC.len());
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct SimpleChord {
@@ -46,6 +51,8 @@ impl TryFrom<&str> for SimpleChord {
             Ok(Self::new(level as u8))
         } else if let Some(level) = CHORD_STRINGS_NASHVILLE.iter().position(|e| *e == s) {
             Ok(Self::new(level as u8))
+        } else if let Some(i) = CHORD_STRINGS_ENHARMONIC.iter().position(|e| *e == s) {
+            Ok(Self::new(CHORD_LEVELS_ENHARMONIC[i]))
         } else {
             Err(Error::Parse(format!("unknown level, {}", s)))
         }
@@ -63,6 +70,22 @@ impl SimpleChord {
 
     pub fn normalize(&self, key: &Self) -> Self {
         self.transpose(12 - key.level)
+    }
+
+    pub(crate) fn combined_level(&self, key: &Self) -> u8 {
+        (self.level + key.level) % 12
+    }
+
+    pub(crate) fn pitch_class(&self) -> u8 {
+        self.level
+    }
+
+    pub(crate) fn root_display_name(m_abs: u8, key: &Self) -> &'static str {
+        if matches!(key.level, 0 | 2 | 3 | 5 | 7 | 9 | 10) {
+            CHORD_STRINGS_SHARP[m_abs as usize]
+        } else {
+            CHORD_STRINGS_FLAT[m_abs as usize]
+        }
     }
 
     pub fn format(&self, key: &SimpleChord, representation: &ChordRepresentation) -> &'static str {
@@ -123,5 +146,60 @@ where
             }
         }
         _ => Err(serde::de::Error::custom("Expected a number")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ChordRepresentation;
+
+    #[test]
+    fn try_from_enharmonic_string_maps_pitch_class() {
+        assert_eq!(SimpleChord::try_from("B#").unwrap().pitch_class(), 3);
+        assert_eq!(SimpleChord::try_from("E#").unwrap().pitch_class(), 8);
+        assert_eq!(SimpleChord::try_from("Cb").unwrap().pitch_class(), 2);
+        assert_eq!(SimpleChord::try_from("Fb").unwrap().pitch_class(), 7);
+    }
+
+    #[test]
+    fn try_from_sharp_and_flat_tables_cover_twelve_classes() {
+        let mut seen = [false; 12];
+        for &name in CHORD_STRINGS_SHARP {
+            let pc = SimpleChord::try_from(name).unwrap().pitch_class();
+            seen[pc as usize] = true;
+        }
+        for &name in CHORD_STRINGS_FLAT {
+            let pc = SimpleChord::try_from(name).unwrap().pitch_class();
+            seen[pc as usize] = true;
+        }
+        assert!(seen.iter().all(|&v| v));
+    }
+
+    #[test]
+    fn combined_level_adds_key_mod_twelve() {
+        let note = SimpleChord::try_from("E").unwrap();
+        let key = SimpleChord::try_from("G").unwrap();
+        assert_eq!(note.combined_level(&key), (7 + 10) % 12);
+    }
+
+    #[test]
+    fn root_display_name_sharp_vs_flat_branch() {
+        let sharp_key = SimpleChord::new(0);
+        let flat_key = SimpleChord::new(1);
+        assert_eq!(SimpleChord::root_display_name(4, &sharp_key), "C#");
+        assert_eq!(SimpleChord::root_display_name(4, &flat_key), "Db");
+    }
+
+    #[test]
+    fn format_default_matches_table_for_natural_c_in_sharp_key() {
+        let c = SimpleChord::try_from("C").unwrap();
+        let key = SimpleChord::default();
+        assert_eq!(c.format(&key, &ChordRepresentation::Default), "C");
+    }
+
+    #[test]
+    fn nashville_degrees_twelve_entries() {
+        assert_eq!(CHORD_STRINGS_NASHVILLE.len(), 12);
     }
 }


### PR DESCRIPTION
## Summary

- Derive default slash-bass note names from the formatted root letter, semitone interval to the bass, and the sharp/flat/enharmonic name tables—without extra fields on `Chord` or `SimpleChord`.
- Parsing still accepts `B#`, `E#`, `Cb`, and `Fb`; trailing characters after the bass note remain a parse error.
- Adds broad unit coverage (Nashville, transpose, serde JSON, alternate keys) and a ChordPro line with multiple slash chords.

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

Fixes #32