### PR TITLE
fix(types): accept comma as chord duration decimal separator

### DIFF
--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -505,7 +505,7 @@ mod tests {
         let input = r#"{title: Durations}
 {key: C}
 {section: Verse}
-[C:4][Am:1.5][G:2][F:1]
+[C:4][Am:1,5][G:2][F:1]
 "#;
         let song = load_string(input).expect("parse");
         assert_eq!(song.sections.len(), 1);

--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -326,11 +326,13 @@ impl Chord {
         }
     }
 
-    /// Parse duration after ':' as clicks (decimal allowed); returns milliclicks (clicks * 1000).
+    /// Parse duration after ':' as clicks (decimal `.` or locale-style `,`); returns milliclicks
+    /// (clicks * 1000). Thousands separators are not supported (only a single fractional
+    /// separator is intended).
     fn parse_duration(s: &str) -> Result<(Option<u32>, &str), Error> {
         if let Some((before, after)) = s.split_once(':') {
-            let clicks: f64 = after
-                .trim()
+            let duration_token = after.trim().replace(',', ".");
+            let clicks: f64 = duration_token
                 .parse()
                 .map_err(|_| Error::Parse("failed to parse the duration".into()))?;
             let milliclicks = (clicks * 1000.0).round().max(0.0) as u32;
@@ -445,6 +447,17 @@ mod test {
 
         let g_2_25 = Chord::from_str("G:2.25").unwrap();
         assert_eq!(g_2_25.get_duration(), Some(2250));
+
+        // Locale-style decimal comma (same values as dot form). See issue #29.
+        let am_1_5_comma = Chord::from_str("Am:1,5").unwrap();
+        assert_eq!(am_1_5_comma.get_duration(), Some(1500));
+
+        let g_2_25_comma = Chord::from_str("G:2,25").unwrap();
+        assert_eq!(g_2_25_comma.get_duration(), Some(2250));
+
+        let paren_comma = Chord::from_str("(C:1,25)").unwrap();
+        assert!(paren_comma.optional);
+        assert_eq!(paren_comma.get_duration(), Some(1250));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Chord durations after `:` now parse when the fractional part uses a comma as the decimal separator (common in German and other locales), e.g. `Am:1,5` matches `Am:1.5`. Integer durations such as `C:4` are unchanged.

## Implementation

- In `Chord::parse_duration`, the trimmed duration token has `,` replaced with `.` before `f64` parsing.
- Doc comment notes that thousands separators are not supported (only a single fractional separator is intended).

## Tests

- Extended `chord_duration_milliclicks` with comma decimals and an optional chord `(C:1,25)`.
- `worship_pro_duration_roundtrip` input uses `[Am:1,5]`; formatted output still uses a dot, existing assertions unchanged.

Fixes #29

Made with [Cursor](https://cursor.com)