### PR TITLE
feat(html): compact 6/8 chord-only bar grid

### DIFF
--- a/src/outputs/html/render_bars.rs
+++ b/src/outputs/html/render_bars.rs
@@ -1,14 +1,17 @@
 use crate::types::{ChordRepresentation, Line, SimpleChord, chord_duration_to_layout_milliclicks};
 
-fn format_bar_beat_slashes(bar: &[(String, u32)], bar_duration: u32, beats_per_bar: u32) -> String {
-    if beats_per_bar == 0 {
-        return String::new();
-    }
+#[derive(Debug)]
+enum BarSym {
+    Chord(String),
+    Slash,
+    Dot,
+}
 
+fn build_bar_symbols(bar: &[(String, u32)], bar_duration: u32, beats_per_bar: u32) -> Vec<BarSym> {
     let beats_per_bar = beats_per_bar as usize;
     let beat_duration = bar_duration / beats_per_bar as u32;
 
-    let mut out = String::with_capacity(beats_per_bar * 4);
+    let mut syms = Vec::with_capacity(beats_per_bar);
 
     let mut prev_chord_idx: Option<usize> = None;
 
@@ -31,30 +34,244 @@ fn format_bar_beat_slashes(bar: &[(String, u32)], bar_duration: u32, beats_per_b
             None
         };
 
-        if beat > 0 {
-            out.push(' ');
-        }
-
         match (chord_idx, prev_chord_idx) {
-            (None, _) => out.push('·'),
+            (None, _) => syms.push(BarSym::Dot),
 
             (Some(idx), Some(prev)) if idx == prev => {
                 let remaining = seg_end.saturating_sub(pos);
                 if remaining >= beat_duration {
-                    out.push('/');
+                    syms.push(BarSym::Slash);
                 } else {
-                    out.push('·');
+                    syms.push(BarSym::Dot);
                 }
             }
 
             (Some(idx), _) => {
                 prev_chord_idx = Some(idx);
-                out.push_str(&bar[idx].0);
+                syms.push(BarSym::Chord(bar[idx].0.clone()));
             }
         }
     }
 
+    syms
+}
+
+fn format_bar_symbols_default(syms: &[BarSym]) -> String {
+    let mut out = String::with_capacity(syms.len() * 4);
+    for (i, s) in syms.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        match s {
+            BarSym::Chord(name) => out.push_str(name),
+            BarSym::Slash => out.push('/'),
+            BarSym::Dot => out.push('·'),
+        }
+    }
     out
+}
+
+fn flush_six_eight_slash_runs(out: &mut String, run: &mut u32) {
+    while *run >= 3 {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push('/');
+        *run -= 3;
+    }
+    while *run > 0 {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push('·');
+        *run -= 1;
+    }
+}
+
+/// Per-eighth grid fallback: merge continuation `/` in runs of up to three eighths, remainder `·`.
+fn six_eight_merge_slash_runs_in_symbols(syms: &[BarSym]) -> String {
+    let mut out = String::with_capacity(syms.len() * 2);
+    let mut slash_run: u32 = 0;
+
+    for s in syms {
+        match s {
+            BarSym::Chord(name) => {
+                flush_six_eight_slash_runs(&mut out, &mut slash_run);
+                if !out.is_empty() {
+                    out.push(' ');
+                }
+                out.push_str(name);
+            }
+            BarSym::Slash => slash_run += 1,
+            BarSym::Dot => {
+                flush_six_eight_slash_runs(&mut out, &mut slash_run);
+                if !out.is_empty() {
+                    out.push(' ');
+                }
+                out.push('·');
+            }
+        }
+    }
+    flush_six_eight_slash_runs(&mut out, &mut slash_run);
+    out
+}
+
+fn fill_six_eighth_chord_grid(bar: &[(String, u32)], bar_duration: u32) -> [Option<String>; 6] {
+    let eighth_dur = bar_duration / 6;
+    let mut grid: [Option<String>; 6] = std::array::from_fn(|_| None);
+
+    let mut seg_idx = 0usize;
+    let mut seg_end = bar.first().map(|(_, dur)| *dur).unwrap_or(0);
+
+    for (eighth, cell) in grid.iter_mut().enumerate() {
+        let pos = eighth as u32 * eighth_dur;
+        while seg_idx < bar.len() && pos >= seg_end {
+            seg_idx += 1;
+            if let Some((_, dur)) = bar.get(seg_idx) {
+                seg_end += dur;
+            }
+        }
+        if seg_idx < bar.len() {
+            *cell = Some(bar[seg_idx].0.clone());
+        }
+    }
+
+    grid
+}
+
+fn first_three_same_chord(grid: &[Option<String>; 6]) -> Option<String> {
+    let a = grid[0].clone()?;
+    if grid[1].as_ref() == Some(&a) && grid[2].as_ref() == Some(&a) {
+        Some(a)
+    } else {
+        None
+    }
+}
+
+fn count_leading_matching(grid: &[Option<String>; 6], from: usize, name: &str) -> usize {
+    grid[from..6]
+        .iter()
+        .take_while(|c| c.as_deref() == Some(name))
+        .count()
+}
+
+fn two_eighth_pairs_all_uniform(grid: &[Option<String>; 6]) -> bool {
+    for pair in 0..3 {
+        let i = pair * 2;
+        match (&grid[i], &grid[i + 1]) {
+            (Some(a), Some(b)) if a == b => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+fn grid_suffix_as_bar(
+    grid: &[Option<String>; 6],
+    start: usize,
+    eighth_dur: u32,
+) -> Vec<(String, u32)> {
+    let mut out = Vec::new();
+    let mut i = start;
+    while i < 6 {
+        let name = match grid[i].clone() {
+            Some(n) => n,
+            None => {
+                i += 1;
+                continue;
+            }
+        };
+        let mut eighths: u32 = 0;
+        while i < 6 && grid[i].as_ref() == Some(&name) {
+            eighths += 1;
+            i += 1;
+        }
+        out.push((name, eighths * eighth_dur));
+    }
+    out
+}
+
+fn push_remainder_tokens(
+    tokens: &mut Vec<String>,
+    grid: &[Option<String>; 6],
+    start: usize,
+    eighth_dur: u32,
+) {
+    if start >= 6 {
+        return;
+    }
+
+    let slice_len = 6 - start;
+    let uniform = grid[start].is_some() && (start..6).all(|j| grid[j] == grid[start]);
+    if uniform {
+        tokens.push(grid[start].clone().unwrap());
+        return;
+    }
+
+    let sub_bar = grid_suffix_as_bar(grid, start, eighth_dur);
+    let sub_bar_dur = slice_len as u32 * eighth_dur;
+    let sub_syms = build_bar_symbols(&sub_bar, sub_bar_dur, slice_len as u32);
+    let s = six_eight_merge_slash_runs_in_symbols(&sub_syms);
+    for t in s.split_whitespace() {
+        tokens.push(t.to_string());
+    }
+}
+
+/// 6/8 chord-only bars: prefer two compound beats (three eighths each) when the first beat is one
+/// chord (`C /` for a whole-bar chord); continuation in the second dotted-quarter uses `/` for one
+/// or three eighths of the same chord, and `·` for each eighth when exactly two eighths remain
+/// before the next chord (e.g. `C · · G`). Else three two-eighth cells when each pair matches
+/// (`C D E`); else per-eighth layout with merged continuation slashes.
+fn format_six_eight_compact(bar: &[(String, u32)], bar_duration: u32) -> String {
+    let eighth_dur = bar_duration / 6;
+
+    let grid = fill_six_eighth_chord_grid(bar, bar_duration);
+
+    if let Some(first_name) = first_three_same_chord(&grid) {
+        let mut tokens = vec![first_name.clone()];
+        let k = count_leading_matching(&grid, 3, first_name.as_str());
+        if k > 0 {
+            if k == 2 {
+                tokens.push("·".to_string());
+                tokens.push("·".to_string());
+            } else {
+                tokens.push("/".to_string());
+            }
+        }
+        let next = 3 + k;
+        push_remainder_tokens(&mut tokens, &grid, next, eighth_dur);
+        return tokens.join(" ");
+    }
+
+    if two_eighth_pairs_all_uniform(&grid) {
+        return format!(
+            "{} {} {}",
+            grid[0].as_ref().unwrap(),
+            grid[2].as_ref().unwrap(),
+            grid[4].as_ref().unwrap()
+        );
+    }
+
+    let syms = build_bar_symbols(bar, bar_duration, 6);
+    six_eight_merge_slash_runs_in_symbols(&syms)
+}
+
+fn format_bar_beat_slashes(
+    bar: &[(String, u32)],
+    bar_duration: u32,
+    beats_per_bar: u32,
+    compact_six_eight: bool,
+) -> String {
+    if beats_per_bar == 0 {
+        return String::new();
+    }
+
+    if compact_six_eight && beats_per_bar == 6 {
+        format_six_eight_compact(bar, bar_duration)
+    } else {
+        let syms = build_bar_symbols(bar, bar_duration, beats_per_bar);
+        format_bar_symbols_default(&syms)
+    }
 }
 
 pub fn render_bars(
@@ -63,6 +280,7 @@ pub fn render_bars(
     representation: &ChordRepresentation,
     bar_duration: u32,
     beats_per_bar: u32,
+    compact_six_eight: bool,
 ) -> String {
     let mut columns: Vec<String> = Vec::new();
     let beats_per_bar = beats_per_bar.max(1);
@@ -104,7 +322,8 @@ pub fn render_bars(
         }
 
         for (idx, bar) in bars.into_iter().enumerate() {
-            let formatted_bar = format_bar_beat_slashes(&bar, bar_duration, beats_per_bar);
+            let formatted_bar =
+                format_bar_beat_slashes(&bar, bar_duration, beats_per_bar, compact_six_eight);
 
             match columns.get_mut(idx) {
                 Some(column) => {
@@ -154,6 +373,19 @@ mod tests {
         Line { parts }
     }
 
+    fn chord_tokens(html: &str) -> Vec<&str> {
+        let chord_span_start = html
+            .find("<span class=\"chord\">")
+            .expect("chord span start not found");
+        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
+        let chord_span_end = html[chord_span_start..]
+            .find("</span>")
+            .expect("chord span end not found")
+            + chord_span_start;
+        let chord_text = &html[chord_span_start..chord_span_end];
+        chord_text.split_whitespace().collect()
+    }
+
     #[test]
     fn bars_show_chords_starting_on_fractional_beats() {
         let bar_duration = 4000;
@@ -164,49 +396,43 @@ mod tests {
         let key: SimpleChord = "C".try_into().unwrap();
         let rep = ChordRepresentation::Default;
 
-        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, false);
 
-        let chord_span_start = html
-            .find("<span class=\"chord\">")
-            .expect("chord span start not found");
-        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
-        let chord_span_end = html[chord_span_start..]
-            .find("</span>")
-            .expect("chord span end not found")
-            + chord_span_start;
-        let chord_text = &html[chord_span_start..chord_span_end];
-
-        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
-        assert_eq!(tokens.len(), beats_per_bar as usize, "{chord_text}");
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens.len(), beats_per_bar as usize, "{tokens:?}");
 
         let unique_chords: HashSet<&str> = tokens
             .iter()
             .copied()
             .filter(|t| *t != "·" && *t != "/")
             .collect();
-        assert_eq!(unique_chords.len(), 2, "{chord_text}");
+        assert_eq!(unique_chords.len(), 2, "{tokens:?}");
     }
 
     #[test]
-    fn bars_six_eighth_one_beat_chords_fill_bar() {
+    fn bars_six_eighth_without_compact_keeps_one_slash_per_eighth() {
         let bar_duration = 3000;
         let beats_per_bar = 6;
         let line = line_with_chords(&["C:6"]);
         let key = SimpleChord::default();
         let rep = ChordRepresentation::Default;
-        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, false);
 
-        let chord_span_start = html
-            .find("<span class=\"chord\">")
-            .expect("chord span start not found");
-        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
-        let chord_span_end = html[chord_span_start..]
-            .find("</span>")
-            .expect("chord span end not found")
-            + chord_span_start;
-        let chord_text = &html[chord_span_start..chord_span_end];
-        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
-        assert_eq!(tokens, vec!["C", "/", "/", "/", "/", "/"], "{chord_text}");
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "/", "/", "/", "/", "/"], "{tokens:?}");
+    }
+
+    #[test]
+    fn bars_six_eighth_compact_full_bar_chord_is_chord_then_slash() {
+        let bar_duration = 3000;
+        let beats_per_bar = 6;
+        let line = line_with_chords(&["C:6"]);
+        let key = SimpleChord::default();
+        let rep = ChordRepresentation::Default;
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, true);
+
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "/"], "{tokens:?}");
     }
 
     #[test]
@@ -216,19 +442,10 @@ mod tests {
         let line = line_with_chords(&["C:4"]);
         let key = SimpleChord::default();
         let rep = ChordRepresentation::Default;
-        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, false);
 
-        let chord_span_start = html
-            .find("<span class=\"chord\">")
-            .expect("chord span start not found");
-        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
-        let chord_span_end = html[chord_span_start..]
-            .find("</span>")
-            .expect("chord span end not found")
-            + chord_span_start;
-        let chord_text = &html[chord_span_start..chord_span_end];
-        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
-        assert_eq!(tokens, vec!["C", "/", "/", "/"], "{chord_text}");
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "/", "/", "/"], "{tokens:?}");
     }
 
     #[test]
@@ -238,27 +455,69 @@ mod tests {
         let line = line_with_chords(&["C:1", "G:1", "C:1", "G:1", "C:1", "G:1"]);
         let key = SimpleChord::default();
         let rep = ChordRepresentation::Default;
-        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, true);
 
-        let chord_span_start = html
-            .find("<span class=\"chord\">")
-            .expect("chord span start not found");
-        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
-        let chord_span_end = html[chord_span_start..]
-            .find("</span>")
-            .expect("chord span end not found")
-            + chord_span_start;
-        let chord_text = &html[chord_span_start..chord_span_end];
-
-        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
-        assert_eq!(tokens.len(), 6, "{chord_text}");
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens.len(), 6, "{tokens:?}");
 
         let unique_chords: HashSet<&str> = tokens
             .iter()
             .copied()
             .filter(|t| *t != "·" && *t != "/")
             .collect();
-        assert_eq!(unique_chords.len(), 2, "{chord_text}");
+        assert_eq!(unique_chords.len(), 2, "{tokens:?}");
+    }
+
+    #[test]
+    fn bars_six_eighth_compact_two_compound_beats_different_chords() {
+        let bar_duration = 3000;
+        let beats_per_bar = 6;
+        let line = line_with_chords(&["C:3", "G:3"]);
+        let key = SimpleChord::default();
+        let rep = ChordRepresentation::Default;
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, true);
+
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "G"], "{tokens:?}");
+    }
+
+    #[test]
+    fn bars_six_eighth_compact_four_and_two_eighths_is_chord_slash_chord() {
+        let bar_duration = 3000;
+        let beats_per_bar = 6;
+        let line = line_with_chords(&["C:4", "G:2"]);
+        let key = SimpleChord::default();
+        let rep = ChordRepresentation::Default;
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, true);
+
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "/", "G"], "{tokens:?}");
+    }
+
+    #[test]
+    fn bars_six_eighth_compact_three_two_eighth_cells() {
+        let bar_duration = 3000;
+        let beats_per_bar = 6;
+        let line = line_with_chords(&["C:2", "D:2", "E:2"]);
+        let key = SimpleChord::default();
+        let rep = ChordRepresentation::Default;
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, true);
+
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "D", "E"], "{tokens:?}");
+    }
+
+    #[test]
+    fn bars_six_eighth_compact_five_and_one_eighth_continuation() {
+        let bar_duration = 3000;
+        let beats_per_bar = 6;
+        let line = line_with_chords(&["C:5", "G:1"]);
+        let key = SimpleChord::default();
+        let rep = ChordRepresentation::Default;
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, true);
+
+        let tokens = chord_tokens(&html);
+        assert_eq!(tokens, vec!["C", "·", "·", "G"], "{tokens:?}");
     }
 
     #[test]
@@ -271,24 +530,14 @@ mod tests {
         let key: SimpleChord = "D".try_into().unwrap();
         let rep = ChordRepresentation::Default;
 
-        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar);
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, false);
 
-        let chord_span_start = html
-            .find("<span class=\"chord\">")
-            .expect("chord span start not found");
-        let chord_span_start = chord_span_start + "<span class=\"chord\">".len();
-        let chord_span_end = html[chord_span_start..]
-            .find("</span>")
-            .expect("chord span end not found")
-            + chord_span_start;
-        let chord_text = &html[chord_span_start..chord_span_end];
-
-        let tokens: Vec<&str> = chord_text.split_whitespace().collect();
+        let tokens = chord_tokens(&html);
         let unique_chords: HashSet<&str> = tokens
             .iter()
             .copied()
             .filter(|t| *t != "·" && *t != "/")
             .collect();
-        assert!(unique_chords.len() >= 2, "{chord_text}");
+        assert!(unique_chords.len() >= 2, "{tokens:?}");
     }
 }

--- a/src/outputs/html/render_section.rs
+++ b/src/outputs/html/render_section.rs
@@ -14,6 +14,7 @@ pub fn render_section(
     language: usize,
     bar_duration: u32,
     beats_per_bar: u32,
+    compact_six_eight: bool,
 ) -> String {
     let mut content = String::new();
     let mut chord_only_line_buffer = Vec::new();
@@ -29,6 +30,7 @@ pub fn render_section(
                     representation,
                     bar_duration,
                     beats_per_bar,
+                    compact_six_eight,
                 ));
                 chord_only_line_buffer.clear();
             }
@@ -48,6 +50,7 @@ pub fn render_section(
             representation,
             bar_duration,
             beats_per_bar,
+            compact_six_eight,
         ));
     }
 

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -40,6 +40,7 @@ impl FormatHTML for &Song {
 
         let beats_per_bar = self.beats_per_bar();
         let bar_duration = self.bar_duration();
+        let compact_six_eight = self.time == Some((6, 8));
         let display_title = self.title_for_language(Some(language));
         let page_template = self
             .sections
@@ -54,6 +55,7 @@ impl FormatHTML for &Song {
                     language,
                     bar_duration,
                     beats_per_bar,
+                    compact_six_eight,
                 )
             })
             .fold(
@@ -186,5 +188,24 @@ mod tests {
         assert!(html_lang2.contains(r#"<h1 class="title">Title DE</h1>"#));
         // No third artist specified, so it must fall back to the first artist.
         assert!(html_lang2.contains(r#"<h2 class="subtitle">Artist DE</h2>"#));
+    }
+
+    #[test]
+    fn html_six_eight_chord_only_line_uses_compact_bar_grid() {
+        let input = r#"{title: Six Eight}
+{key: C}
+{time: 6/8}
+{section: Prog}
+[C:6]
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let html = (&song).format_html(None, Some(&rep), None, None);
+
+        assert!(
+            html.contains("C /") && !html.contains("C / · ·"),
+            "expected compound 6/8 bar (chord + slash for second dotted quarter), got: {}",
+            html.chars().take(2000).collect::<String>()
+        );
     }
 }


### PR DESCRIPTION
Implements multi-resolution 6/8 chord-only bar rendering: compound dotted-quarter halves when the first three eighths agree, three two-eighth cells when each pair is uniform, otherwise per-eighth fallback with slash merging. Wires `compact_six_eight` from `Song.time == Some((6, 8))` through `render_section` into `render_bars`.

Fixes #31

Made with [Cursor](https://cursor.com)