### PR TITLE
refactor(song)!: vec-only titles, artists, languages

### DIFF
--- a/src/inputs/chord_pro/iter_section.rs
+++ b/src/inputs/chord_pro/iter_section.rs
@@ -1,15 +1,12 @@
 use std::collections::BTreeMap;
 
 pub struct SectionIterator<'a> {
-    title: &'a mut Option<String>,
-    titles: &'a mut Option<Vec<String>>,
+    titles: &'a mut Vec<String>,
     subtitle: &'a mut Option<String>,
     copyright: &'a mut Option<String>,
     key: &'a mut Option<String>,
-    artist: &'a mut Option<String>,
-    artists: &'a mut Option<Vec<String>>,
-    language: &'a mut Option<String>,
-    languages: &'a mut Option<Vec<String>>,
+    artists: &'a mut Vec<String>,
+    languages: &'a mut Vec<String>,
     tempo: &'a mut Option<u32>,
     time: &'a mut Option<(u32, u32)>,
     tags: &'a mut BTreeMap<String, String>,
@@ -22,28 +19,22 @@ impl<'a> SectionIterator<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         content: &'a str,
-        title: &'a mut Option<String>,
-        titles: &'a mut Option<Vec<String>>,
+        titles: &'a mut Vec<String>,
         subtitle: &'a mut Option<String>,
         copyright: &'a mut Option<String>,
         key: &'a mut Option<String>,
-        artist: &'a mut Option<String>,
-        artists: &'a mut Option<Vec<String>>,
-        language: &'a mut Option<String>,
-        languages: &'a mut Option<Vec<String>>,
+        artists: &'a mut Vec<String>,
+        languages: &'a mut Vec<String>,
         tempo: &'a mut Option<u32>,
         time: &'a mut Option<(u32, u32)>,
         tags: &'a mut BTreeMap<String, String>,
     ) -> Self {
         Self {
-            title,
             titles,
             subtitle,
             copyright,
             key,
-            artist,
             artists,
-            language,
             languages,
             tempo,
             time,
@@ -101,34 +92,22 @@ impl<'a> Iterator for SectionIterator<'a> {
                     // Handle indexed metadata directives: title/titleN, language/languageN, artist/artistN.
                     if let Some(idx) = Self::parse_indexed_key(key, "title") {
                         let title_val = Self::parse_simple_value(value);
-                        let titles_vec = self.titles.get_or_insert_with(Vec::new);
-                        if titles_vec.len() <= idx {
-                            titles_vec.resize(idx + 1, String::new());
+                        if self.titles.len() <= idx {
+                            self.titles.resize(idx + 1, String::new());
                         }
-                        titles_vec[idx] = title_val.clone();
-                        if idx == 0 || self.title.is_none() {
-                            *self.title = Some(title_val);
-                        }
+                        self.titles[idx] = title_val;
                     } else if let Some(idx) = Self::parse_indexed_key(key, "language") {
                         let lang_val = Self::parse_simple_value(value);
-                        let langs_vec = self.languages.get_or_insert_with(Vec::new);
-                        if langs_vec.len() <= idx {
-                            langs_vec.resize(idx + 1, String::new());
+                        if self.languages.len() <= idx {
+                            self.languages.resize(idx + 1, String::new());
                         }
-                        langs_vec[idx] = lang_val.clone();
-                        if idx == 0 || self.language.is_none() {
-                            *self.language = Some(lang_val);
-                        }
+                        self.languages[idx] = lang_val;
                     } else if let Some(idx) = Self::parse_indexed_key(key, "artist") {
                         let artist_val = Self::parse_simple_value(value);
-                        let artists_vec = self.artists.get_or_insert_with(Vec::new);
-                        if artists_vec.len() <= idx {
-                            artists_vec.resize(idx + 1, String::new());
+                        if self.artists.len() <= idx {
+                            self.artists.resize(idx + 1, String::new());
                         }
-                        artists_vec[idx] = artist_val.clone();
-                        if idx == 0 || self.artist.is_none() {
-                            *self.artist = Some(artist_val);
-                        }
+                        self.artists[idx] = artist_val;
                     } else {
                         match key {
                             "meta" => {

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -162,29 +162,23 @@ pub fn load(path: &str) -> Result<Song, Error> {
 }
 
 pub fn load_string(input: &str) -> Result<Song, Error> {
-    let mut title = None;
-    let mut titles = None;
+    let mut titles = Vec::new();
     let mut subtitle = None;
     let mut copyright = None;
     let mut key = None;
-    let mut artist = None;
-    let mut artists = None;
-    let mut language = None;
-    let mut languages = None;
+    let mut artists = Vec::new();
+    let mut languages = Vec::new();
     let mut tempo = None;
     let mut time = None;
     let mut tags = BTreeMap::new();
 
     let sections = SectionIterator::new(
         input,
-        &mut title,
         &mut titles,
         &mut subtitle,
         &mut copyright,
         &mut key,
-        &mut artist,
         &mut artists,
-        &mut language,
         &mut languages,
         &mut tempo,
         &mut time,
@@ -224,16 +218,15 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
     }
     let key_simple: SimpleChord = key_str.try_into()?;
 
-    let title = title.ok_or(Error::Parse("no title given".into()))?;
+    if !titles.iter().any(|t| !t.is_empty()) {
+        return Err(Error::Parse("no title given".into()));
+    }
     Ok(Song {
-        title,
         titles,
         subtitle,
         copyright,
         key: Some(key_simple),
-        artist,
         artists,
-        language,
         languages,
         tempo,
         time,
@@ -434,7 +427,7 @@ mod tests {
 [||:][G][C][D][ :||]
 "#;
         let song = load_string(input).expect("import must not fail on repeat markers");
-        assert_eq!(song.title.as_str(), "Test");
+        assert_eq!(song.title(), "Test");
         assert_eq!(song.sections.len(), 1);
         assert_eq!(song.sections[0].lines.len(), 1);
 
@@ -548,7 +541,7 @@ mod tests {
 [C]Line
 "#;
         let song = load_string(input).expect("parse");
-        assert_eq!(song.language.as_deref(), Some("en"));
+        assert_eq!(song.language(), "en");
         let langs = song.language_list().expect("language list");
         assert_eq!(langs, vec!["en", "de", "fr"]);
     }
@@ -564,16 +557,14 @@ mod tests {
 [C]Line
 "#;
         let song = load_string(input).expect("parse");
-        assert_eq!(song.artist.as_deref(), Some("First Artist"));
+        assert_eq!(song.artist(), "First Artist");
         assert_eq!(
-            song.artists.as_deref(),
-            Some(
-                &[
-                    "First Artist".to_string(),
-                    "Second Artist".to_string(),
-                    "Third Artist".to_string()
-                ][..]
-            )
+            song.artists,
+            vec![
+                "First Artist".to_string(),
+                "Second Artist".to_string(),
+                "Third Artist".to_string()
+            ]
         );
         let artist_list = song.artist_list().expect("artist list");
         assert_eq!(
@@ -590,11 +581,8 @@ mod tests {
 [C]Line
 "#;
         let song_single = load_string(input_single).expect("parse single");
-        assert_eq!(song_single.title, "My Song Title");
-        assert_eq!(
-            song_single.titles.as_deref(),
-            Some(&["My Song Title".to_string()][..])
-        );
+        assert_eq!(song_single.title(), "My Song Title");
+        assert_eq!(song_single.titles, vec!["My Song Title".to_string()]);
 
         let input_multi = r#"{title: Main}
 {title2: "Secondary Title"}
@@ -603,10 +591,10 @@ mod tests {
 [C]Line
 "#;
         let song_multi = load_string(input_multi).expect("parse multi");
-        assert_eq!(song_multi.title, "Main");
+        assert_eq!(song_multi.title(), "Main");
         assert_eq!(
-            song_multi.titles.as_deref(),
-            Some(&["Main".to_string(), "Secondary Title".to_string()][..])
+            song_multi.titles,
+            vec!["Main".to_string(), "Secondary Title".to_string()]
         );
         // Language-aware helper should pick the second title for language index 1
         // and fall back to the primary for out-of-range indices.

--- a/src/inputs/ultimate_guitar/mod.rs
+++ b/src/inputs/ultimate_guitar/mod.rs
@@ -100,15 +100,12 @@ pub fn load_string(content: &str, title: &str, artist: &str, key: &str) -> Resul
     sections.extend(rest);
 
     Ok(Song {
-        title: title.into(),
-        titles: None,
+        titles: vec![title.into()],
         subtitle: None,  // TODO: parse subtitle
         copyright: None, // TODO: parse copyright
         key: Some(SimpleChord::guess_key(key)),
-        artist: Some(artist.into()),
-        artists: None,
-        language: None, // TODO: parse language
-        languages: None,
+        artists: vec![artist.into()],
+        languages: vec![],
         tempo,
         time,
         tags: Default::default(),
@@ -158,8 +155,8 @@ mod tests {
     fn load_html_parses_fixture_ug_page() {
         let html = fixture_html_with_store();
         let song = load_html(&html).expect("load_html should parse fixture");
-        assert_eq!(song.title.as_str(), "Test Song");
-        assert_eq!(song.artist.as_deref(), Some("Test Artist"));
+        assert_eq!(song.title(), "Test Song");
+        assert_eq!(song.artist(), "Test Artist");
         assert_eq!(song.sections.len(), 1);
         assert_eq!(song.sections[0].title.as_str(), "Verse 1");
         assert_eq!(song.sections[0].lines.len(), 1);

--- a/src/outputs/chord_pro/render_song.rs
+++ b/src/outputs/chord_pro/render_song.rs
@@ -19,23 +19,24 @@ impl FormatChordPro for &Song {
 
         // Title(s)
         if worship_pro_features {
-            if let Some(titles) = &self.titles {
-                for (idx, title) in titles.iter().enumerate() {
-                    if title.is_empty() {
-                        continue;
-                    }
-                    let key = if idx == 0 {
-                        "title".to_string()
-                    } else {
-                        format!("title{}", idx + 1)
-                    };
-                    meta.push(format!("{{{}{}{}}}", key, separator, title));
+            let mut any = false;
+            for (idx, title) in self.titles.iter().enumerate() {
+                if title.is_empty() {
+                    continue;
                 }
-            } else {
-                meta.push(format!("{{title{}{}}}", separator, self.title));
+                any = true;
+                let key = if idx == 0 {
+                    "title".to_string()
+                } else {
+                    format!("title{}", idx + 1)
+                };
+                meta.push(format!("{{{}{}{}}}", key, separator, title));
+            }
+            if !any {
+                meta.push(format!("{{title{}{}}}", separator, self.title()));
             }
         } else {
-            meta.push(format!("{{title{}{}}}", separator, self.title));
+            meta.push(format!("{{title{}{}}}", separator, self.title()));
         }
 
         // Subtitle
@@ -57,44 +58,36 @@ impl FormatChordPro for &Song {
 
         // Artist(s)
         if worship_pro_features {
-            if let Some(artists) = &self.artists {
-                for (idx, artist) in artists.iter().enumerate() {
-                    if artist.is_empty() {
-                        continue;
-                    }
-                    let key = if idx == 0 {
-                        "artist".to_string()
-                    } else {
-                        format!("artist{}", idx + 1)
-                    };
-                    meta.push(format!("{{{}{}{}}}", key, separator, artist));
+            for (idx, artist) in self.artists.iter().enumerate() {
+                if artist.is_empty() {
+                    continue;
                 }
-            } else if let Some(artist) = &self.artist {
-                meta.push(format!("{{artist{}{}}}", separator, artist));
+                let key = if idx == 0 {
+                    "artist".to_string()
+                } else {
+                    format!("artist{}", idx + 1)
+                };
+                meta.push(format!("{{{}{}{}}}", key, separator, artist));
             }
-        } else if let Some(artist) = &self.artist {
-            meta.push(format!("{{artist{}{}}}", separator, artist));
+        } else if !self.artist().is_empty() {
+            meta.push(format!("{{artist{}{}}}", separator, self.artist()));
         }
 
         // Language(s)
         if worship_pro_features {
-            if let Some(langs) = &self.languages {
-                for (idx, lang) in langs.iter().enumerate() {
-                    if lang.is_empty() {
-                        continue;
-                    }
-                    let key = if idx == 0 {
-                        "language".to_string()
-                    } else {
-                        format!("language{}", idx + 1)
-                    };
-                    meta.push(format!("{{{}{}{}}}", key, separator, lang));
+            for (idx, lang) in self.languages.iter().enumerate() {
+                if lang.is_empty() {
+                    continue;
                 }
-            } else if let Some(language) = &self.language {
-                meta.push(format!("{{language{}{}}}", separator, language));
+                let key = if idx == 0 {
+                    "language".to_string()
+                } else {
+                    format!("language{}", idx + 1)
+                };
+                meta.push(format!("{{{}{}{}}}", key, separator, lang));
             }
-        } else if let Some(language) = &self.language {
-            meta.push(format!("{{language{}{}}}", separator, language));
+        } else if !self.language().is_empty() {
+            meta.push(format!("{{language{}{}}}", separator, self.language()));
         }
 
         // Tempo & time

--- a/src/outputs/html/render_section.rs
+++ b/src/outputs/html/render_section.rs
@@ -107,15 +107,12 @@ mod tests {
         };
 
         Song {
-            title: "Test".to_string(),
-            titles: None,
+            titles: vec!["Test".to_string()],
             subtitle: None,
             copyright: None,
             key: Some(SimpleChord::default()),
-            artist: None,
-            artists: None,
-            language: None,
-            languages: None,
+            artists: vec![],
+            languages: vec![],
             tempo: None,
             time: None,
             tags: Default::default(),

--- a/src/types/song.rs
+++ b/src/types/song.rs
@@ -6,20 +6,18 @@ use super::{Section, SimpleChord};
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Song {
-    /// Primary title of the song (typically the first title in the `{title: ...}` directive).
-    pub title: String,
-    /// Optional list of titles for different languages, in the same order as the `{language: ...}` directive.
-    /// When present, index 0 should always match `title`.
-    pub titles: Option<Vec<String>>,
+    /// Titles from `{title}` / `{titleN}`; index 0 is the primary (`title()`).
+    #[serde(default)]
+    pub titles: Vec<String>,
     pub subtitle: Option<String>,
     pub copyright: Option<String>,
     pub key: Option<SimpleChord>,
-    pub artist: Option<String>,
-    /// Optional list of artists; when present, index 0 should usually match `artist`.
-    pub artists: Option<Vec<String>>,
-    pub language: Option<String>,
-    /// Optional list of language codes; when present, index 0 should usually match `language`.
-    pub languages: Option<Vec<String>>,
+    /// Artists from `{artist}` / `{artistN}`; index 0 is the primary (`artist()`).
+    #[serde(default)]
+    pub artists: Vec<String>,
+    /// Language codes from `{language}` / `{languageN}`; index 0 is the primary (`language()`).
+    #[serde(default)]
+    pub languages: Vec<String>,
     pub tempo: Option<u32>,
     pub time: Option<(u32, u32)>,
     /// Custom tags (e.g. scripture, hymn_type) from ChordPro `{meta: name value}`.
@@ -30,6 +28,21 @@ pub struct Song {
 }
 
 impl Song {
+    /// Primary title: first entry in `titles`, or empty when the vector is empty.
+    pub fn title(&self) -> &str {
+        self.titles.first().map(String::as_str).unwrap_or("")
+    }
+
+    /// Primary artist: first entry in `artists`, or empty when the vector is empty.
+    pub fn artist(&self) -> &str {
+        self.artists.first().map(String::as_str).unwrap_or("")
+    }
+
+    /// Primary language code: first entry in `languages`, or empty when the vector is empty.
+    pub fn language(&self) -> &str {
+        self.languages.first().map(String::as_str).unwrap_or("")
+    }
+
     pub fn transpose(&mut self, key: SimpleChord) -> &mut Self {
         self.key = Some(key);
         self
@@ -69,16 +82,15 @@ impl Song {
     ///
     /// If `language` is `Some(idx)` and `self.titles` contains a non-empty
     /// title at that index, that title is returned. Otherwise, this falls
-    /// back to the primary `self.title`.
+    /// back to the primary `title()`.
     pub fn title_for_language(&self, language: Option<usize>) -> &str {
         let idx = language.unwrap_or(0);
-        if let Some(titles) = &self.titles
-            && let Some(candidate) = titles.get(idx)
+        if let Some(candidate) = self.titles.get(idx)
             && !candidate.is_empty()
         {
             return candidate;
         }
-        &self.title
+        self.title()
     }
 
     pub fn move_chords_to_next_vowels(mut self) -> Self {
@@ -99,43 +111,31 @@ impl Song {
         self
     }
 
-    /// Returns a slice of artists, preferring the structured `artists` field when present.
+    /// Returns a slice of artists when `artists` is non-empty.
     pub fn artist_slice(&self) -> Option<&[String]> {
-        if let Some(artists) = &self.artists {
-            if artists.is_empty() {
-                return None;
-            }
-            return Some(artists.as_slice());
+        if self.artists.is_empty() {
+            None
+        } else {
+            Some(self.artists.as_slice())
         }
-        self.artist.as_ref().map(std::slice::from_ref)
     }
 
+    /// Returns a clone of language codes when `languages` is non-empty.
     pub fn language_list(&self) -> Option<Vec<String>> {
-        if let Some(langs) = &self.languages {
-            if langs.is_empty() {
-                return None;
-            }
-            return Some(langs.clone());
+        if self.languages.is_empty() {
+            None
+        } else {
+            Some(self.languages.clone())
         }
-
-        self.language.as_ref().map(|langs| {
-            langs
-                .split_whitespace()
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-                .collect()
-        })
     }
 
-    /// Returns a list of artists, preferring the structured `artists` field when present.
+    /// Returns a clone of artists when `artists` is non-empty.
     pub fn artist_list(&self) -> Option<Vec<String>> {
-        if let Some(artists) = &self.artists {
-            if artists.is_empty() {
-                return None;
-            }
-            return Some(artists.clone());
+        if self.artists.is_empty() {
+            None
+        } else {
+            Some(self.artists.clone())
         }
-        self.artist.as_ref().map(|a| vec![a.clone()])
     }
 }
 
@@ -155,6 +155,23 @@ pub fn chord_duration_to_layout_milliclicks(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn primary_getters_return_empty_when_vectors_empty() {
+        let song = Song::default();
+        assert_eq!(song.title(), "");
+        assert_eq!(song.artist(), "");
+        assert_eq!(song.language(), "");
+    }
+
+    #[test]
+    fn serde_missing_metadata_vectors_default_empty() {
+        let json = r#"{"sections":[]}"#;
+        let s: Song = serde_json::from_str(json).unwrap();
+        assert!(s.titles.is_empty());
+        assert!(s.artists.is_empty());
+        assert!(s.languages.is_empty());
+    }
 
     #[test]
     fn bar_duration_milliclicks() {
@@ -231,10 +248,15 @@ mod tests {
     }
 
     #[test]
-    fn language_list_prefers_structured_languages() {
+    fn language_list_returns_none_when_empty() {
+        let song = Song::default();
+        assert!(song.language_list().is_none());
+    }
+
+    #[test]
+    fn language_list_clones_non_empty_languages() {
         let song = Song {
-            language: Some("legacy should be ignored when vector present".to_string()),
-            languages: Some(vec!["en".to_string(), "de".to_string(), "fr".to_string()]),
+            languages: vec!["en".to_string(), "de".to_string(), "fr".to_string()],
             ..Song::default()
         };
         let langs = song.language_list().expect("language list");
@@ -244,12 +266,11 @@ mod tests {
     #[test]
     fn title_for_language_prefers_titles_vector_and_falls_back() {
         let song = Song {
-            title: "Primary".to_string(),
-            titles: Some(vec![
+            titles: vec![
                 "Primary".to_string(),
                 "Secondary".to_string(),
                 String::new(),
-            ]),
+            ],
             ..Song::default()
         };
 
@@ -261,5 +282,15 @@ mod tests {
         // Out-of-range or empty entries fall back to primary.
         assert_eq!(song.title_for_language(Some(2)), "Primary");
         assert_eq!(song.title_for_language(Some(10)), "Primary");
+    }
+
+    #[test]
+    fn title_for_language_falls_back_when_primary_slot_empty() {
+        let song = Song {
+            titles: vec![String::new(), "OnlySecond".to_string()],
+            ..Song::default()
+        };
+        assert_eq!(song.title_for_language(None), "");
+        assert_eq!(song.title_for_language(Some(1)), "OnlySecond");
     }
 }


### PR DESCRIPTION
## Summary

Implements [#42](https://github.com/xilefmusics/chordlib/issues/42): `Song` stores metadata only in `titles`, `artists`, and `languages` as `Vec<String>` (with `#[serde(default)]` for forward-compatible deserialization). Scalar `title` / `artist` / `language` and `Option<Vec<_>>` are removed.

## API

- **Primary strings:** `Song::title()`, `Song::artist()`, and `Song::language()` return the first vector element or `""` when empty.
- **Helpers:** `title_for_language`, `artist_slice`, `language_list`, and `artist_list` are updated for the new shape.

## Breaking change

Public struct field layout changed. Callers must use the vectors and/or getters instead of the old fields.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test`
- `cargo doc --no-deps`

Fixes #42