### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.8.0] — Song vectors, chord spelling & HTML bars
+
+### ✨ New features
+
+- **🎸 HTML equal-length chord segments** — When every chord segment in a full bar has the same duration, render chord names only (no per-beat `/` or `·` continuation tokens). Partial bars and unequal lengths keep the beat grid. (#47)
+
+### 🐛 Fixes
+
+- **Chord spelling (slash bass)** — `Chord::format` now emits extensions before the slash bass (e.g. `C4/E` instead of the incorrect `C/E4`). (#44)
+- **HTML bar continuation** — When explicit chord segments end before the bar duration, remaining beat cells continue the last harmony with `/` instead of `·`. (#45)
+
+### ⚠️ Breaking change & migration
+
+**`Song` uses vectors only for titles, artists, and languages (#46)**
+
+Scalar `title` / `artist` / `language` and `Option<Vec<…>>` wrappers are removed. Primary values come from index 0 via `title()`, `artist()`, and `language()` (empty string when the vector is empty). ChordPro parsing and Worship Pro I/O use the vectors directly; serde defaults missing fields to empty `Vec`s.
+
+**What to do:** Update downstream code to the new public `Song` fields and getters. If you deserialize stored JSON, align payloads with the new shape or rely on serde defaults where applicable.
+
+---
+
 ## [0.7.0] — HTML bars, chord parsing & layout
 
 ### ✨ New features
@@ -84,6 +105,7 @@ The internal song model is used by some users for storage (e.g. JSON in a DB). S
 
 See git history or tags for earlier releases.
 
+[0.8.0]: https://github.com/xilefmusics/chordlib/releases/tag/0.8.0
 [0.7.0]: https://github.com/xilefmusics/chordlib/releases/tag/0.7.0
 [0.6.0]: https://github.com/xilefmusics/chordlib/releases/tag/0.6.0
 [0.5.0]: https://github.com/xilefmusics/chordlib/releases/tag/0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordlib"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Work with chord-and-lyrics songs: parse, transform, and render them to multiple formats"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

Prepares **chordlib 0.8.0**: bumps `package.version` in `Cargo.toml` and adds a full **[0.8.0]** section to `CHANGELOG.md` for everything merged on `main` since tag **0.7.0**.

## What ships in 0.8.0

- **Feature:** HTML bar rendering omits `/` and `·` when every chord segment in a full bar has the same duration (#47).
- **Fixes:** Correct slash-bass chord formatting (`C4/E` vs `C/E4`) (#44); HTML continuation uses `/` after a short chord tail (#45).
- **Breaking:** `Song` metadata is vec-only for titles, artists, and languages; scalars and `Option<Vec<…>>` wrappers removed (#46). See the changelog for migration notes.

## Checklist

- [x] `CHANGELOG.md` matches the intended release notes for this version.
- [x] Version in `Cargo.toml` matches the changelog heading.

## After merge

Cut the release on the merge commit: tag **`0.8.0`** and create a GitHub release whose body matches the new changelog section (per project convention).