### PR TITLE
fix(nashville): scale degrees relative to song key

### DIFF
--- a/src/inputs/chord_pro/iter_part.rs
+++ b/src/inputs/chord_pro/iter_part.rs
@@ -1,18 +1,20 @@
 use crate::error::Error;
-use crate::types::{Chord, Part};
+use crate::types::{Chord, Part, SimpleChord};
 
 pub struct PartIterator<'a> {
     bar_duration: u32,
     line: &'a str,
     chord_cache: Vec<Chord>,
+    song_key: Option<SimpleChord>,
 }
 
 impl<'a> PartIterator<'a> {
-    pub fn new(line: &'a str, bar_duration: u32) -> Self {
+    pub fn new(line: &'a str, bar_duration: u32, song_key: Option<SimpleChord>) -> Self {
         Self {
             bar_duration,
             line: line.trim(),
             chord_cache: Vec::new(),
+            song_key,
         }
     }
 
@@ -77,7 +79,18 @@ impl<'a> PartIterator<'a> {
         if is_repeat_marker {
             return Some(("", text).try_into());
         }
-        Some((chord, text).try_into())
+        let chord_opt = match chord.trim() {
+            "" => None,
+            s => match Chord::from_str_with_key(s, self.song_key.as_ref()) {
+                Ok(c) => Some(c),
+                Err(e) => return Some(Err(e)),
+            },
+        };
+        Some(Ok(Part {
+            chord: chord_opt,
+            languages: vec![text.to_string()],
+            comment: false,
+        }))
     }
 
     fn handle_pipe_chord(&mut self) -> Option<Result<Part, Error>> {
@@ -92,10 +105,12 @@ impl<'a> PartIterator<'a> {
                 break;
             }
 
-            self.chord_cache.push(match chord.parse::<Chord>() {
-                Ok(c) => c,
-                Err(e) => return Some(Err(e)),
-            });
+            self.chord_cache.push(
+                match Chord::from_str_with_key(chord, self.song_key.as_ref()) {
+                    Ok(c) => c,
+                    Err(e) => return Some(Err(e)),
+                },
+            );
 
             self.line = &self.line[end_idx + 1..];
         }

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -246,7 +246,7 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
     if !titles.iter().any(|t| !t.is_empty()) {
         return Err(Error::Parse("no title given".into()));
     }
-    Ok(Song {
+    let mut song = Song {
         titles,
         subtitle,
         copyright,
@@ -257,9 +257,12 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
         time,
         tags,
         sections,
+    };
+    // Chords parsed with `song_key` are already key-relative; absolute roots need one normalize.
+    if song_key.is_none() {
+        song.normalize();
     }
-    .normalize()
-    .clone())
+    Ok(song)
 }
 
 #[cfg(test)]

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -10,6 +10,23 @@ use std::collections::BTreeMap;
 use crate::error::Error;
 use crate::types::{Line, Part, Section, SimpleChord, Song};
 
+/// First `{key: ...}` directive in the file (same ordering as `SectionIterator`).
+fn chordpro_key_directive(input: &str) -> Option<String> {
+    for line in input.lines() {
+        let line = line.trim();
+        let Some(inner) = line.strip_prefix('{').and_then(|s| s.strip_suffix('}')) else {
+            continue;
+        };
+        let Some((k, v)) = inner.split_once(':') else {
+            continue;
+        };
+        if k.trim() == "key" {
+            return Some(v.trim().to_string());
+        }
+    }
+    None
+}
+
 /// If `line` is `{repeat}` or `{repeat: N}` (N ≥ 1), returns Some(repeat_count).
 /// `{repeat}` → 2. Otherwise returns None (not a repeat directive).
 /// Returns Err if it looks like a repeat directive but is invalid (e.g. `{repeat: 0}`).
@@ -172,6 +189,12 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
     let mut time = None;
     let mut tags = BTreeMap::new();
 
+    let song_key = chordpro_key_directive(input)
+        .as_ref()
+        .map(|k| k.trim())
+        .filter(|k| !k.is_empty())
+        .and_then(|k| SimpleChord::try_from(k).ok());
+
     let sections = SectionIterator::new(
         input,
         &mut titles,
@@ -185,7 +208,9 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
         &mut tags,
     )
     .map(|(keyword, lines)| {
-        build_section_from_lines(keyword, &lines, |line| PartIterator::new(line, 4000))
+        build_section_from_lines(keyword, &lines, |line| {
+            PartIterator::new(line, 4000, song_key.clone())
+        })
     })
     .collect::<Result<Vec<Section>, Error>>()?;
 
@@ -198,7 +223,7 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
                     .map(|(num, denom)| 1000 * num * 4 / denom)
                     .unwrap_or(4000);
                 build_section_from_lines(keyword, &lines, |line| {
-                    PartIterator::new(line, bar_duration)
+                    PartIterator::new(line, bar_duration, song_key.clone())
                 })
             })
             .collect::<Result<Vec<Section>, Error>>()?
@@ -478,6 +503,28 @@ mod tests {
         assert!(out.contains("[1]") && out.contains("[4]") && out.contains("[5]"));
         let again = load_string(&out).expect("round-trip");
         assert_eq!(again.key, song.key);
+    }
+
+    /// Letter chords with `{key: C}` must render as scale degrees relative to C (not as if key were A).
+    /// See https://github.com/xilefmusics/chordlib/issues/49
+    #[test]
+    fn nashville_letter_chords_key_c_issue_49() {
+        let input = r#"{title: Repro}
+{key: C}
+{section: Verse}
+[G][C]
+"#;
+        let song = load_string(input).expect("parse");
+        let key = song.key.as_ref().unwrap();
+        let rep = ChordRepresentation::Nashville;
+        let parts: Vec<_> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].format(key, &rep), "5");
+        assert_eq!(parts[1].format(key, &rep), "1");
     }
 
     #[test]

--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -145,6 +145,12 @@ impl Kind {
     }
 }
 
+/// Chord symbol: root and optional slash bass are [`SimpleChord`] pitch-class levels.
+///
+/// In a song loaded from ChordPro with a known `{key: …}`, roots are stored as **semitone
+/// intervals from the song key** (0 = tonic). From [`Chord::from_str`] without a key, roots are
+/// **absolute** pitch class (A = 0); call [`Chord::normalize`] with the song key before formatting
+/// in that representation.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Chord {
     main: SimpleChord,
@@ -170,6 +176,8 @@ impl Chord {
         result
     }
 
+    /// Interprets [`SimpleChord`] roots as **absolute** pitch class (A = 0) and rewrites them as
+    /// semitone intervals from `key` (same convention as keyed ChordPro ingest).
     pub fn normalize(self, key: &SimpleChord) -> Self {
         let mut result = self;
         result.main = result.main.normalize(key);
@@ -275,20 +283,26 @@ impl Chord {
         )))
     }
 
-    /// Like [`parse_simple_chord`], but when `key` is `Some` and the root is a Nashville numeral
-    /// (`1`, `b3`, …), resolves it to absolute pitch class relative to the song key before
-    /// [`Song::normalize`].
+    /// Like [`parse_simple_chord`], but when `key` is `Some`, roots are **intervals from the song
+    /// key** (0–11): Nashville numerals use the chromatic degree index; letter names use
+    /// `(absolute_pitch - key + 12) % 12`.
     fn parse_simple_chord_with_key<'a>(
         s: &'a str,
         key: Option<&SimpleChord>,
     ) -> Result<(SimpleChord, &'a str), Error> {
-        if let Some(k) = key
+        if let Some(_k) = key
             && let Some((degree_idx, consumed)) = match_nashville_chord_prefix(s)
         {
-            let main = SimpleChord::new((k.pitch_class() + degree_idx as u8) % 12);
+            let main = SimpleChord::new(degree_idx as u8);
             return Ok((main, &s[consumed..]));
         }
-        Self::parse_simple_chord(s)
+        let (parsed, rest) = Self::parse_simple_chord(s)?;
+        if let Some(k) = key {
+            let relative = SimpleChord::new((parsed.pitch_class() + 12 - k.pitch_class()) % 12);
+            Ok((relative, rest))
+        } else {
+            Ok((parsed, rest))
+        }
     }
 
     fn parse_kind(s: &str) -> (Kind, &str) {
@@ -356,8 +370,8 @@ impl Chord {
         Ok((None, s))
     }
 
-    /// Parse a chord symbol; when `key` is `Some` (song key from ChordPro), Nashville numeral
-    /// roots (`1`, `b7`, …) are interpreted relative to that key.
+    /// Parse a chord symbol. When `key` is `Some`, root and slash bass are stored as semitone
+    /// intervals from that key; when `None`, roots are absolute pitch class (see [`Chord`]).
     pub fn from_str_with_key(mut s: &str, key: Option<&SimpleChord>) -> Result<Self, Error> {
         let optional = s.starts_with('(') && s.ends_with(')');
         if optional {

--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-use super::chord_simple::{CHORD_STRINGS_ENHARMONIC, CHORD_STRINGS_FLAT, CHORD_STRINGS_SHARP};
+use super::chord_simple::{
+    CHORD_STRINGS_ENHARMONIC, CHORD_STRINGS_FLAT, CHORD_STRINGS_SHARP, match_nashville_chord_prefix,
+};
 use super::{ChordRepresentation, SimpleChord};
 use crate::error::Error;
 
@@ -273,6 +275,22 @@ impl Chord {
         )))
     }
 
+    /// Like [`parse_simple_chord`], but when `key` is `Some` and the root is a Nashville numeral
+    /// (`1`, `b3`, …), resolves it to absolute pitch class relative to the song key before
+    /// [`Song::normalize`].
+    fn parse_simple_chord_with_key<'a>(
+        s: &'a str,
+        key: Option<&SimpleChord>,
+    ) -> Result<(SimpleChord, &'a str), Error> {
+        if let Some(k) = key
+            && let Some((degree_idx, consumed)) = match_nashville_chord_prefix(s)
+        {
+            let main = SimpleChord::new((k.pitch_class() + degree_idx as u8) % 12);
+            return Ok((main, &s[consumed..]));
+        }
+        Self::parse_simple_chord(s)
+    }
+
     fn parse_kind(s: &str) -> (Kind, &str) {
         if s.len() >= 4 {
             let l4: usize = s.chars().take(4).map(|c| c.len_utf8()).sum();
@@ -306,11 +324,11 @@ impl Chord {
         (Kind::Major, s)
     }
 
-    fn parse_slash_bass(s: &str) -> Result<Option<SimpleChord>, Error> {
+    fn parse_slash_bass(s: &str, key: Option<&SimpleChord>) -> Result<Option<SimpleChord>, Error> {
         if s.is_empty() {
             return Ok(None);
         }
-        let (chord, rest) = Self::parse_simple_chord(s)?;
+        let (chord, rest) = Self::parse_simple_chord_with_key(s, key)?;
         if !rest.is_empty() {
             return Err(Error::Parse(format!(
                 "invalid characters after bass note: {rest}",
@@ -337,22 +355,20 @@ impl Chord {
         }
         Ok((None, s))
     }
-}
 
-impl FromStr for Chord {
-    type Err = Error;
-
-    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+    /// Parse a chord symbol; when `key` is `Some` (song key from ChordPro), Nashville numeral
+    /// roots (`1`, `b7`, …) are interpreted relative to that key.
+    pub fn from_str_with_key(mut s: &str, key: Option<&SimpleChord>) -> Result<Self, Error> {
         let optional = s.starts_with('(') && s.ends_with(')');
         if optional {
             s = &s[1..s.len() - 1];
         }
 
         let (duration, s) = Self::parse_duration(s)?;
-        let (main, s) = Self::parse_simple_chord(s)?;
+        let (main, s) = Self::parse_simple_chord_with_key(s, key)?;
         let (kind, s) = Self::parse_kind(s);
         let (var, s) = Self::parse_var(s);
-        let base = Self::parse_slash_bass(s)?;
+        let base = Self::parse_slash_bass(s, key)?;
 
         Ok(Self {
             main,
@@ -362,6 +378,14 @@ impl FromStr for Chord {
             duration,
             optional,
         })
+    }
+}
+
+impl FromStr for Chord {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str_with_key(s, None)
     }
 }
 
@@ -665,6 +689,45 @@ mod test {
         ] {
             assert_eq!(fmt_nashville(sym, &key), want, "{sym}");
         }
+    }
+
+    /// Nashville numerals are scale degrees relative to the song key (not only when key is A).
+    /// See https://github.com/xilefmusics/chordlib/issues/49
+    #[test]
+    fn nashville_normalized_tonic_dominant_key_c_and_g() {
+        let key_c = SimpleChord::try_from("C").unwrap();
+        let c = Chord::from_str("C").unwrap().normalize(&key_c);
+        let g = Chord::from_str("G").unwrap().normalize(&key_c);
+        assert_eq!(c.format(&key_c, &ChordRepresentation::Nashville), "1");
+        assert_eq!(g.format(&key_c, &ChordRepresentation::Nashville), "5");
+
+        let key_g = SimpleChord::try_from("G").unwrap();
+        let g1 = Chord::from_str("G").unwrap().normalize(&key_g);
+        let c4 = Chord::from_str("C").unwrap().normalize(&key_g);
+        let d5 = Chord::from_str("D").unwrap().normalize(&key_g);
+        assert_eq!(g1.format(&key_g, &ChordRepresentation::Nashville), "1");
+        assert_eq!(c4.format(&key_g, &ChordRepresentation::Nashville), "4");
+        assert_eq!(d5.format(&key_g, &ChordRepresentation::Nashville), "5");
+    }
+
+    /// Same chord roots in two keys: transpose roots by the key change → same Nashville numerals.
+    /// See https://github.com/xilefmusics/chordlib/issues/49
+    #[test]
+    fn nashville_transposition_invariant_issue_49() {
+        let key_c = SimpleChord::try_from("C").unwrap();
+        let key_d = SimpleChord::try_from("D").unwrap();
+        let c = Chord::from_str("C").unwrap().normalize(&key_c);
+        let g = Chord::from_str("G").unwrap().normalize(&key_c);
+        let d = Chord::from_str("D").unwrap().normalize(&key_d);
+        let a = Chord::from_str("A").unwrap().normalize(&key_d);
+        assert_eq!(
+            c.format(&key_c, &ChordRepresentation::Nashville),
+            d.format(&key_d, &ChordRepresentation::Nashville)
+        );
+        assert_eq!(
+            g.format(&key_c, &ChordRepresentation::Nashville),
+            a.format(&key_d, &ChordRepresentation::Nashville)
+        );
     }
 
     #[test]

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -13,6 +13,20 @@ static CHORD_STRINGS_NASHVILLE: &[&str] = &[
     "1", "b2", "2", "b3", "3", "4", "b5", "5", "b6", "6", "b7", "7",
 ];
 
+/// Longest `CHORD_STRINGS_NASHVILLE` entry that prefixes `s` (degree index and byte length).
+pub(crate) fn match_nashville_chord_prefix(s: &str) -> Option<(usize, usize)> {
+    let mut best: Option<(usize, usize)> = None;
+    for (idx, &name) in CHORD_STRINGS_NASHVILLE.iter().enumerate() {
+        if s.starts_with(name) {
+            let len = name.len();
+            if best.is_none_or(|(_, l)| len > l) {
+                best = Some((idx, len));
+            }
+        }
+    }
+    best
+}
+
 pub(crate) static CHORD_STRINGS_ENHARMONIC: &[&str] = &["B#", "E#", "Cb", "Fb"];
 pub(crate) static CHORD_LEVELS_ENHARMONIC: &[u8] = &[3, 8, 2, 7];
 
@@ -91,7 +105,9 @@ impl SimpleChord {
     pub fn format(&self, key: &SimpleChord, representation: &ChordRepresentation) -> &'static str {
         match representation {
             ChordRepresentation::Nashville => {
-                CHORD_STRINGS_NASHVILLE[((self.level + key.level) % 12) as usize]
+                // Scale degree relative to the song key: after `Chord::normalize`, `self.level` is
+                // the semitone interval from the key root to the chord root.
+                CHORD_STRINGS_NASHVILLE[(self.level % 12) as usize]
             }
             ChordRepresentation::Default => match key.level {
                 0 | 2 | 3 | 5 | 7 | 9 | 10 => {

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -82,6 +82,8 @@ impl SimpleChord {
         Self::new(self.level + level)
     }
 
+    /// Rewrites **absolute** pitch class (`self`) to a semitone interval from `key` (tonic of
+    /// `key` at its own pitch class).
     pub fn normalize(&self, key: &Self) -> Self {
         self.transpose(12 - key.level)
     }


### PR DESCRIPTION
Closes #49.

Nashville output was indexing with `(root + key) % 12` after normalize, which double-counted the key (only correct when key is A).

- Format normalized roots with `CHORD_STRINGS_NASHVILLE[root.level % 12]`.
- Parse Nashville numeral tokens in ChordPro against the song key so roots are absolute pitch before normalize.
- Wire ChordPro bracket parsing to `Chord::from_str_with_key`; scan first `{key: …}` for key context.

Tests cover key C/G, transposition invariance, and letter chords `[G][C]` in key C.

Made with [Cursor](https://cursor.com)