### PR TITLE
fix(chord): Unicode space separators for keys and lyrics

### DIFF
--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -8,6 +8,7 @@ use iter_space_section::SpaceSectionIterator;
 use std::collections::BTreeMap;
 
 use crate::error::Error;
+use crate::text::remove_space_separators;
 use crate::types::{Line, Part, Section, SimpleChord, Song};
 
 /// First `{key: ...}` directive in the file (same ordering as `SectionIterator`).
@@ -229,8 +230,9 @@ pub fn load_string(input: &str) -> Result<Song, Error> {
             .collect::<Result<Vec<Section>, Error>>()?
     };
 
-    let key_str = key.ok_or(Error::Parse("no key given".into()))?;
-    let key_str = key_str.trim();
+    let key_stored = key.ok_or(Error::Parse("no key given".into()))?;
+    let key_clean = remove_space_separators(&key_stored);
+    let key_str = key_clean.as_ref().trim();
     if key_str
         .chars()
         .next()
@@ -578,6 +580,13 @@ mod tests {
 "#;
         let r = load_string(input);
         assert!(r.is_err(), "{{key: 1}} must be rejected");
+    }
+
+    #[test]
+    fn key_directive_strips_typographic_space_before_sharp() {
+        let input = "{title: T}\n{key: C\u{205F}#}\n{section: Verse}\n[C]\n";
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.key.as_ref().unwrap().pitch_class(), 4);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,13 @@
 //! See the README for end-to-end examples.
 
 mod error;
+mod unicode_space;
+
+/// Normalization helpers for user-facing text (e.g. Unicode space separators to ASCII).
+pub mod text {
+    pub use crate::unicode_space::{normalize_space_separators, remove_space_separators};
+}
+
 pub use error::Error;
 
 pub mod inputs;

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
+use crate::text::remove_space_separators;
 
 pub(crate) static CHORD_STRINGS_SHARP: &[&str] = &[
     "A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#",
@@ -120,18 +121,34 @@ impl SimpleChord {
         }
     }
 
+    /// Best-effort key from a free-form label (e.g. `"Dm"`, `"F# / major"`). Uses the first
+    /// 1–2 **Unicode characters** (not bytes) to match `TryFrom<&str>`, so multi-byte names do not
+    /// cause panics. [Unicode `Space_Separator`](crate::text::remove_space_separators) (Zs) “fake
+    /// spaces” (e.g. U+00A0, U+205F) are **removed** so tokens like `C#` and `C #` both resolve.
     pub fn guess_key(key: &str) -> SimpleChord {
+        let cleaned = remove_space_separators(key);
+        let key = cleaned.as_ref().trim_start();
         if key.is_empty() {
             return SimpleChord::default();
         }
 
-        let chord = match SimpleChord::try_from(&key[..1]) {
+        let mut it = key.char_indices();
+        let (i0, c0) = match it.next() {
+            Some(p) => p,
+            None => return SimpleChord::default(),
+        };
+        let one_end = i0 + c0.len_utf8();
+        let one = &key[i0..one_end];
+
+        let chord = match SimpleChord::try_from(one) {
             Ok(chord) => chord,
             Err(_) => return SimpleChord::default(),
         };
 
-        let chord = if key.len() > 1 {
-            SimpleChord::try_from(&key[..2]).unwrap_or(chord)
+        let chord = if let Some((i1, c1)) = it.next() {
+            let two_end = i1 + c1.len_utf8();
+            let two = &key[i0..two_end];
+            SimpleChord::try_from(two).unwrap_or(chord)
         } else {
             chord
         };
@@ -214,6 +231,31 @@ mod tests {
         let c = SimpleChord::try_from("C").unwrap();
         let key = SimpleChord::default();
         assert_eq!(c.format(&key, &ChordRepresentation::Default), "C");
+    }
+
+    #[test]
+    fn guess_key_uses_chars_not_bytes_for_two_letter_names() {
+        assert_eq!(
+            SimpleChord::guess_key("Bb").pitch_class(),
+            SimpleChord::try_from("Bb").unwrap().pitch_class()
+        );
+        assert_eq!(
+            SimpleChord::guess_key("D#").pitch_class(),
+            SimpleChord::try_from("D#").unwrap().pitch_class()
+        );
+    }
+
+    #[test]
+    fn guess_key_does_not_panic_on_medium_mathematical_space() {
+        // U+205F is 3 UTF-8 bytes; old byte slices would panic on similar strings.
+        let s = format!("D\u{205F} ");
+        assert_eq!(SimpleChord::guess_key(&s).pitch_class(), 5);
+        assert_eq!(SimpleChord::guess_key("C\u{205F}#").pitch_class(), 4);
+        assert_eq!(SimpleChord::guess_key("C#").pitch_class(), 4);
+        assert_eq!(
+            SimpleChord::guess_key("So\u{205f}pl"),
+            SimpleChord::default()
+        );
     }
 
     #[test]

--- a/src/types/part.rs
+++ b/src/types/part.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use super::{Chord, SimpleChord};
 use crate::error::Error;
+use crate::text::normalize_space_separators;
 
 fn find_first_vowel(text: &str) -> Option<usize> {
     text.char_indices()
@@ -42,6 +43,8 @@ fn find_first_vowel(text: &str) -> Option<usize> {
 }
 
 fn normalize_whitespace(input: &str) -> String {
+    let input = normalize_space_separators(input);
+    let input = input.as_ref();
     let mut result = String::with_capacity(input.len());
     let mut in_whitespace = false;
 

--- a/src/unicode_space.rs
+++ b/src/unicode_space.rs
@@ -1,0 +1,74 @@
+//! Map Unicode “space separator” (Zs) and common typographic space code points to U+0020.
+//! See <https://www.unicode.org/reports/tr44/#General_Category_Values> (category Zs).
+use std::borrow::Cow;
+
+/// `true` for characters in the Unicode `Space_Separator` (Zs) class, except the ordinary
+/// ASCII space (already U+0020). Unicode defines these as distinct from tabs and newlines
+/// (Cc, or Zl / Zp line/paragraph break).
+const fn is_non_ascii_zs(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00A0}' // NO-BREAK SPACE
+            | '\u{1680}' // OGHAM SPACE MARK
+            | '\u{2000}'
+            ..='\u{200A}' // EN QUAD … HAIR SPACE
+            | '\u{202F}' // NARROW NO-BREAK SPACE
+            | '\u{205F}' // MEDIUM MATHEMATICAL SPACE
+            | '\u{3000}' // IDEOGRAPHIC SPACE
+    )
+}
+
+/// Replaces every non-ASCII `Space_Separator` (Zs) with `U+0020`. Tabs, newlines, and other
+/// non-Zs control characters are left unchanged, so this is safe for line-oriented text.
+///
+/// If the string is unchanged, returns [`Cow::Borrowed`] (no allocation).
+pub fn normalize_space_separators(s: &str) -> Cow<'_, str> {
+    if !s.chars().any(is_non_ascii_zs) {
+        return Cow::Borrowed(s);
+    }
+    Cow::Owned(
+        s.chars()
+            .map(|c| if is_non_ascii_zs(c) { ' ' } else { c })
+            .collect(),
+    )
+}
+
+/// Removes every `Space_Separator` (Zs) character that [`normalize_space_separators`] rewrites. Use
+/// this for **machine** tokens (e.g. a chord key `C#` or `Dm`) so a typographic space between `C`
+/// and `#` is dropped instead of becoming `U+0020`, which would not match a strict parse.
+pub fn remove_space_separators(s: &str) -> Cow<'_, str> {
+    if !s.chars().any(is_non_ascii_zs) {
+        return Cow::Borrowed(s);
+    }
+    Cow::Owned(s.chars().filter(|&c| !is_non_ascii_zs(c)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_change_when_no_zs() {
+        let s = "C D\n\t";
+        let c = normalize_space_separators(s);
+        assert!(matches!(c, Cow::Borrowed(_)));
+        assert_eq!(c.as_ref(), s);
+    }
+
+    #[test]
+    fn nnbsp_nbsp_ideograph_space_to_ascii() {
+        let s = format!("A\u{00A0}B\u{202F}C\u{3000}D");
+        let t = normalize_space_separators(&s);
+        assert_eq!(t.as_ref(), "A B C D");
+    }
+
+    #[test]
+    fn medium_mathematical_space() {
+        assert_eq!(normalize_space_separators("So\u{205f}pl").as_ref(), "So pl");
+    }
+
+    #[test]
+    fn remove_mms_between_letters() {
+        assert_eq!(remove_space_separators("C\u{205F}#"), "C#");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `chordlib::text::{normalize_space_separators, remove_space_separators}` mapping Unicode `Space_Separator` (Zs) characters to ASCII space or stripping them (no new dependencies).
- **remove_space_separators**: `SimpleChord::guess_key`, ChordPro `{key: ...}` parsing (keeps tokens like `C#` valid when a typographic space appears between `C` and `#`).
- **normalize_space_separators**: applied before `Part` lyric whitespace collapse.

## Tests

`cargo fmt`, `cargo test`, `cargo clippy --all-features -- -D warnings` pass locally.

Made with [Cursor](https://cursor.com)