### PR TITLE
fix(chordpro): skip empty [] inside pipe bars

### DIFF
--- a/src/inputs/chord_pro/iter_part.rs
+++ b/src/inputs/chord_pro/iter_part.rs
@@ -105,6 +105,12 @@ impl<'a> PartIterator<'a> {
                 break;
             }
 
+            // `[]` inside a pipe bar: same as standalone `[]` in `handle_bracket` (no chord)
+            if chord.trim().is_empty() {
+                self.line = &self.line[end_idx + 1..];
+                continue;
+            }
+
             self.chord_cache.push(
                 match Chord::from_str_with_key(chord, self.song_key.as_ref()) {
                     Ok(c) => c,

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -356,6 +356,18 @@ mod tests {
         );
     }
 
+    /// `[]` after chords in a pipe bar (SongSelect-style layout) is a spacer, not a chord.
+    #[test]
+    fn chordpro_empty_brackets_inside_pipe_bar() {
+        let input = r#"{title: Pipe + empty}
+{key: B}
+{section: Intro}
+[|][C][D]     []
+"#;
+        let song = load_string(input).expect("parse");
+        assert_eq!(song.sections[0].lines.len(), 1);
+    }
+
     /// Copyright meta must round-trip with ChordPro spelling `{copyright:...}`, not `coptyright`.
     /// See https://github.com/xilefmusics/chordlib/issues/51
     #[test]


### PR DESCRIPTION
## Summary
ChordPro imports failed with `can not parse a simple chord from the string: ` when a line used SongSelect-style bar notation (`[|]...`) and ended with empty brackets `[]` (spacer / no chord).

`handle_bracket` already maps standalone `[]` to no chord; `handle_pipe_chord` did not and tried to parse an empty string as a chord.

## Changes
- Skip trimmed-empty `[]` pairs inside `handle_pipe_chord`, consistent with `handle_bracket`.
- Add regression test `chordpro_empty_brackets_inside_pipe_bar`.

Made with [Cursor](https://cursor.com)