### PR TITLE
fix(chordpro): partition pipe bars to full measure

### DIFF
--- a/src/inputs/chord_pro/iter_part.rs
+++ b/src/inputs/chord_pro/iter_part.rs
@@ -129,11 +129,19 @@ impl<'a> PartIterator<'a> {
             return Some(Err(Error::Parse("bar does not contain chords".into())));
         };
 
-        let duration = self.bar_duration / self.chord_cache.len() as u32;
-        let cache = std::mem::take(&mut self.chord_cache); // replaces it with an empty vec
+        let n = self.chord_cache.len();
+        let base = self.bar_duration / n as u32;
+        // `bar_duration / n` truncates; assign the remainder to the last chord so each pipe bar
+        // partitions the measure exactly and the next `[|]` never inherits a sub-beat gap.
+        let last_duration = self.bar_duration - base * (n as u32 - 1);
+        let cache = std::mem::take(&mut self.chord_cache);
         self.chord_cache = cache
             .into_iter()
-            .map(|chord| chord.duration(duration))
+            .enumerate()
+            .map(|(i, chord)| {
+                let duration = if i + 1 == n { last_duration } else { base };
+                chord.duration(duration)
+            })
             .collect();
 
         Some(Ok(Part::new_chord(self.chord_cache.remove(0))))

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -368,6 +368,101 @@ mod tests {
         assert_eq!(song.sections[0].lines.len(), 1);
     }
 
+    /// Pipe bars split the measure evenly; remainder from `bar_duration / n` goes on the last chord
+    /// so durations sum to a full bar (no gap that would offset the next `[|]` group).
+    #[test]
+    fn pipe_bar_durations_partition_measure_exactly() {
+        let input = r#"{title: T}
+{key: C}
+{time: 4/4}
+{section: S}
+[|][C][D][E][|][F][|]
+"#;
+        let song = load_string(input).expect("parse");
+        let parts: Vec<_> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(parts.len(), 4);
+        let d0 = parts[0].get_duration().expect("d0");
+        let d1 = parts[1].get_duration().expect("d1");
+        let d2 = parts[2].get_duration().expect("d2");
+        let d3 = parts[3].get_duration().expect("d3");
+        assert_eq!(d0 + d1 + d2, 4000, "first pipe group fills one bar");
+        assert_eq!(d3, 4000, "second pipe group is one chord per bar");
+        assert_eq!((d0, d1, d2), (1333, 1333, 1334));
+    }
+
+    /// Two chords in a pipe bar: equal halves, no remainder; both get `bar_duration / 2`.
+    #[test]
+    fn pipe_bar_two_chords_equal_halves() {
+        let input = r#"{title: T}
+{key: C}
+{time: 4/4}
+{section: S}
+[|][C][G][|]
+"#;
+        let song = load_string(input).expect("parse");
+        let parts: Vec<_> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].get_duration(), Some(2000));
+        assert_eq!(parts[1].get_duration(), Some(2000));
+    }
+
+    /// One chord in a pipe bar fills the measure.
+    #[test]
+    fn pipe_bar_one_chord_full_measure() {
+        let input = r#"{title: T}
+{key: C}
+{time: 4/4}
+{section: S}
+[|][Am][|]
+"#;
+        let song = load_string(input).expect("parse");
+        let parts: Vec<_> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].get_duration(), Some(4000));
+    }
+
+    /// When `bar_duration` is not divisible by `n`, the last chord absorbs the remainder
+    /// (e.g. 6 chords in 4/4: five at 666 ms, last 670 ms).
+    #[test]
+    fn pipe_bar_six_chords_remainder_on_last() {
+        let input = r#"{title: T}
+{key: C}
+{time: 4/4}
+{section: S}
+[|][C][D][E][F][G][Am][|]
+"#;
+        let song = load_string(input).expect("parse");
+        let parts: Vec<_> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .collect();
+        assert_eq!(parts.len(), 6);
+        let sum: u32 = parts
+            .iter()
+            .map(|c| c.get_duration().expect("duration"))
+            .sum();
+        assert_eq!(sum, 4000);
+        assert_eq!(parts[0].get_duration(), Some(666));
+        assert_eq!(parts[1].get_duration(), Some(666));
+        assert_eq!(parts[2].get_duration(), Some(666));
+        assert_eq!(parts[3].get_duration(), Some(666));
+        assert_eq!(parts[4].get_duration(), Some(666));
+        assert_eq!(parts[5].get_duration(), Some(670));
+    }
+
     /// Copyright meta must round-trip with ChordPro spelling `{copyright:...}`, not `coptyright`.
     /// See https://github.com/xilefmusics/chordlib/issues/51
     #[test]

--- a/src/outputs/html/render_bars.rs
+++ b/src/outputs/html/render_bars.rs
@@ -441,6 +441,21 @@ mod tests {
         chord_text.split_whitespace().collect()
     }
 
+    /// Text inside the n-th `<span class="chord">` (0 = first), up to the closing `</span>`.
+    fn nth_chord_cell_raw(html: &str, n: usize) -> &str {
+        let mut rest = html;
+        for _ in 0..n {
+            let start = rest.find("<span class=\"chord\">").expect("chord cell");
+            rest = &rest[start + "<span class=\"chord\">".len()..];
+            let end = rest.find("</span>").expect("chord cell end");
+            rest = &rest[end + "</span>".len()..];
+        }
+        let start = rest.find("<span class=\"chord\">").expect("chord cell");
+        let inner = &rest[start + "<span class=\"chord\">".len()..];
+        let end = inner.find("</span>").expect("chord cell end");
+        &inner[..end]
+    }
+
     #[test]
     fn bars_show_chords_starting_on_fractional_beats() {
         let bar_duration = 4000;
@@ -501,6 +516,21 @@ mod tests {
 
         let tokens = chord_tokens(&html);
         assert_eq!(tokens, vec!["C"], "{tokens:?}");
+    }
+
+    /// Durations 1333+1333+1334+4000 match a 4/4 pipe bar of three chords plus a full-bar chord
+    /// (see `pipe_bar_durations_partition_measure_exactly`). The second column must be a single
+    /// chord name with no `/` or `·` tail from a short bar spill.
+    #[test]
+    fn bars_exact_pipe_partition_second_column_single_chord_name() {
+        let bar_duration = 4000;
+        let beats_per_bar = 4;
+        let line = line_with_chords(&["C:1.333", "D:1.333", "E:1.334", "F:4"]);
+        let key = SimpleChord::default();
+        let rep = ChordRepresentation::Default;
+        let html = render_bars(&[&line], &key, &rep, bar_duration, beats_per_bar, false);
+
+        assert_eq!(nth_chord_cell_raw(&html, 1), "F", "html:\n{html}");
     }
 
     #[test]

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -213,4 +213,40 @@ mod tests {
             html.chars().take(2000).collect::<String>()
         );
     }
+
+    /// After a multi-chord pipe bar that partitions the measure exactly, the next `[|]…[|]`
+    /// group’s chord must render as a full bar (single token, no spurious `F /` or `F ·` tails).
+    #[test]
+    fn html_pipe_bar_next_group_full_bar_no_continuation_fillers() {
+        let input = r#"{title: Pipe}
+{key: C}
+{time: 4/4}
+{section: S}
+[|][C][D][E][|][F][|]
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let html = (&song).format_html(None, Some(&rep), None, None);
+
+        assert!(
+            html.contains(r#"<span class="chord">F</span><span class="bar">|</span></span></p>"#),
+            "second bar should be a lone F in its cell; got: {}",
+            html.split(r#"<span class="keyword">S</span>"#)
+                .nth(1)
+                .unwrap_or(&html)
+                .chars()
+                .take(800)
+                .collect::<String>()
+        );
+        assert!(
+            !html.contains("F /") && !html.contains("F ·"),
+            "full-bar F after a complete pipe group must not use beat continuation tokens; got: {}",
+            html.split(r#"<span class="keyword">S</span>"#)
+                .nth(1)
+                .unwrap_or(&html)
+                .chars()
+                .take(800)
+                .collect::<String>()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

ChordPro pipe groups `[|]…[|]` split the bar evenly across chords using integer division (`bar_duration / n`). That left a 1 ms remainder when the bar length is not divisible by `n`, so the **next** pipe group started with a tiny spill and chord-only HTML showed bogus `/` and `·` (e.g. `F# / / ·` after a three-chord bar).

## Change

- Assign the remainder to the **last** chord in each group so segments always sum to the full measure.
- Tests: parser (2- and 6-chord groups, single-chord bar), `render_bars` second-column check, full `format_html` fragment.

## Verification

`cargo test` (100 tests).

Made with [Cursor](https://cursor.com)