### PR TITLE
fix(types): spell keyed Nashville b7 with diatonic flat seventh

### DIFF
--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -2,124 +2,10 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 use super::chord_simple::{
-    CHORD_STRINGS_ENHARMONIC, CHORD_STRINGS_FLAT, CHORD_STRINGS_SHARP, match_nashville_chord_prefix,
+    format_nashville_root_default, format_slash_bass_default, match_nashville_chord_prefix,
 };
 use super::{ChordRepresentation, SimpleChord};
 use crate::error::Error;
-
-const DIATONIC_LETTERS: &str = "CDEFGAB";
-
-fn letter_natural_pc(c: char) -> Option<u8> {
-    match c {
-        'A' => Some(0),
-        'B' => Some(2),
-        'C' => Some(3),
-        'D' => Some(5),
-        'E' => Some(7),
-        'F' => Some(8),
-        'G' => Some(10),
-        _ => None,
-    }
-}
-
-fn advance_diatonic_letter(root: char, steps: usize) -> Option<char> {
-    let i = DIATONIC_LETTERS.find(root)?;
-    Some(DIATONIC_LETTERS.as_bytes()[(i + steps) % 7] as char)
-}
-
-fn parse_root_nominal_letter(root_display: &str, expect_m_abs: u8) -> Option<char> {
-    let mut cs = root_display.chars();
-    let letter = cs.next()?;
-    if !matches!(letter, 'A'..='G') {
-        return None;
-    }
-    let nat = letter_natural_pc(letter)?;
-    let acc: i16 = cs.fold(0i16, |a, ch| match ch {
-        '#' => a + 1,
-        'b' => a - 1,
-        _ => a,
-    });
-    let pc = (nat as i16 + acc).rem_euclid(12) as u8;
-    if pc != expect_m_abs {
-        return None;
-    }
-    Some(letter)
-}
-
-fn spell_letter_to_pc(letter: char, target_pc: u8) -> Option<&'static str> {
-    for &name in CHORD_STRINGS_SHARP
-        .iter()
-        .chain(CHORD_STRINGS_FLAT.iter())
-        .chain(CHORD_STRINGS_ENHARMONIC.iter())
-    {
-        if !name.starts_with(letter) {
-            continue;
-        }
-        let Ok(sc) = SimpleChord::try_from(name) else {
-            continue;
-        };
-        if sc.pitch_class() == target_pc {
-            return Some(name);
-        }
-    }
-    None
-}
-
-fn spell_slash_bass_from_intervals(
-    root_letter: char,
-    _m_abs: u8,
-    b_abs: u8,
-    interval: u8,
-) -> Option<&'static str> {
-    match interval {
-        0 => spell_letter_to_pc(root_letter, b_abs),
-        1 | 2 => {
-            let t = advance_diatonic_letter(root_letter, 1)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        3 | 4 => {
-            let t = advance_diatonic_letter(root_letter, 2)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        5 => {
-            let t = advance_diatonic_letter(root_letter, 3)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        6 => {
-            let fifth = advance_diatonic_letter(root_letter, 4)?;
-            if let Some(s) = spell_letter_to_pc(fifth, b_abs) {
-                return Some(s);
-            }
-            let fourth = advance_diatonic_letter(root_letter, 3)?;
-            spell_letter_to_pc(fourth, b_abs)
-        }
-        7 => {
-            let t = advance_diatonic_letter(root_letter, 4)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        8..=11 => {
-            let t = advance_diatonic_letter(root_letter, 5)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        _ => None,
-    }
-}
-
-fn format_slash_bass_default(
-    main: &SimpleChord,
-    base: &SimpleChord,
-    key: &SimpleChord,
-) -> &'static str {
-    let m_abs = main.combined_level(key);
-    let b_abs = base.combined_level(key);
-    let interval = (b_abs + 12 - m_abs) % 12;
-    let root_display = SimpleChord::root_display_name(m_abs, key);
-    let Some(root_letter) = parse_root_nominal_letter(root_display, m_abs) else {
-        return base.format(key, &ChordRepresentation::Default);
-    };
-    spell_slash_bass_from_intervals(root_letter, m_abs, b_abs, interval)
-        .unwrap_or_else(|| base.format(key, &ChordRepresentation::Default))
-}
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub enum Kind {
@@ -160,6 +46,9 @@ pub struct Chord {
     duration: Option<u32>,
     #[serde(default)]
     optional: bool,
+    /// True when the root was parsed as a Nashville numeral with a song key (`b7`, `5`, …).
+    #[serde(default)]
+    main_is_nashville_numeral: bool,
 }
 
 impl Chord {
@@ -180,6 +69,7 @@ impl Chord {
     /// semitone intervals from `key` (same convention as keyed ChordPro ingest).
     pub fn normalize(self, key: &SimpleChord) -> Self {
         let mut result = self;
+        result.main_is_nashville_numeral = false;
         result.main = result.main.normalize(key);
         result.base = result.base.clone().map(|base| base.normalize(key));
         result
@@ -257,7 +147,13 @@ impl Chord {
         format!(
             "{}{}{}{}{}{}",
             optional_start,
-            self.main.format(key, representation),
+            if matches!(representation, ChordRepresentation::Default)
+                && self.main_is_nashville_numeral
+            {
+                format_nashville_root_default(&self.main, key)
+            } else {
+                self.main.format(key, representation)
+            },
             self.kind.format(),
             self.var,
             slash.unwrap_or_default(),
@@ -289,19 +185,19 @@ impl Chord {
     fn parse_simple_chord_with_key<'a>(
         s: &'a str,
         key: Option<&SimpleChord>,
-    ) -> Result<(SimpleChord, &'a str), Error> {
-        if let Some(_k) = key
+    ) -> Result<(SimpleChord, &'a str, bool), Error> {
+        if key.is_some()
             && let Some((degree_idx, consumed)) = match_nashville_chord_prefix(s)
         {
             let main = SimpleChord::new(degree_idx as u8);
-            return Ok((main, &s[consumed..]));
+            return Ok((main, &s[consumed..], true));
         }
         let (parsed, rest) = Self::parse_simple_chord(s)?;
         if let Some(k) = key {
             let relative = SimpleChord::new((parsed.pitch_class() + 12 - k.pitch_class()) % 12);
-            Ok((relative, rest))
+            Ok((relative, rest, false))
         } else {
-            Ok((parsed, rest))
+            Ok((parsed, rest, false))
         }
     }
 
@@ -342,7 +238,7 @@ impl Chord {
         if s.is_empty() {
             return Ok(None);
         }
-        let (chord, rest) = Self::parse_simple_chord_with_key(s, key)?;
+        let (chord, rest, _) = Self::parse_simple_chord_with_key(s, key)?;
         if !rest.is_empty() {
             return Err(Error::Parse(format!(
                 "invalid characters after bass note: {rest}",
@@ -379,7 +275,7 @@ impl Chord {
         }
 
         let (duration, s) = Self::parse_duration(s)?;
-        let (main, s) = Self::parse_simple_chord_with_key(s, key)?;
+        let (main, s, main_is_nashville_numeral) = Self::parse_simple_chord_with_key(s, key)?;
         let (kind, s) = Self::parse_kind(s);
         let (var, s) = Self::parse_var(s);
         let base = Self::parse_slash_bass(s, key)?;
@@ -391,6 +287,7 @@ impl Chord {
             var: var.to_string(),
             duration,
             optional,
+            main_is_nashville_numeral,
         })
     }
 }
@@ -428,6 +325,37 @@ mod test {
             "from_str({sym:?}) with key level {}",
             key.pitch_class()
         );
+    }
+
+    /// Nashville `b7` uses the flat seventh letter name; see issue #58.
+    /// Pitch class 9 (`Gb` / `F#`) is stored without enharmonic preference, so the tonic is
+    /// spelled like `F#` and the lowered seventh is `E` (not `Fb`).
+    #[test]
+    fn nashville_b7_default_spelling_diatonic_flat_seventh_issue_58() {
+        let keys = [
+            ("A", "G"),
+            ("Bb", "Ab"),
+            ("B", "A"),
+            ("C", "Bb"),
+            ("Db", "Cb"),
+            ("D", "C"),
+            ("Eb", "Db"),
+            ("E", "D"),
+            ("F", "Eb"),
+            ("Gb", "E"),
+            ("G", "F"),
+            ("Ab", "Gb"),
+        ];
+        for (key_name, want_root) in keys {
+            let key = SimpleChord::try_from(key_name).unwrap();
+            let s = Chord::from_str_with_key("b7", Some(&key))
+                .unwrap()
+                .format(&key, &ChordRepresentation::Default);
+            assert_eq!(
+                s, want_root,
+                "b7 in key {key_name} should spell as {want_root}"
+            );
+        }
     }
 
     #[test]

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::Error;
 use crate::text::remove_space_separators;
 
+use super::ChordRepresentation;
+
 pub(crate) static CHORD_STRINGS_SHARP: &[&str] = &[
     "A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#",
 ];
@@ -71,6 +73,104 @@ impl TryFrom<&str> for SimpleChord {
         } else {
             Err(Error::Parse(format!("unknown level, {}", s)))
         }
+    }
+}
+
+const DIATONIC_LETTERS: &str = "CDEFGAB";
+
+fn letter_natural_pc(c: char) -> Option<u8> {
+    match c {
+        'A' => Some(0),
+        'B' => Some(2),
+        'C' => Some(3),
+        'D' => Some(5),
+        'E' => Some(7),
+        'F' => Some(8),
+        'G' => Some(10),
+        _ => None,
+    }
+}
+
+fn advance_diatonic_letter(root: char, steps: usize) -> Option<char> {
+    let i = DIATONIC_LETTERS.find(root)?;
+    Some(DIATONIC_LETTERS.as_bytes()[(i + steps) % 7] as char)
+}
+
+fn parse_root_nominal_letter(root_display: &str, expect_m_abs: u8) -> Option<char> {
+    let mut cs = root_display.chars();
+    let letter = cs.next()?;
+    if !matches!(letter, 'A'..='G') {
+        return None;
+    }
+    let nat = letter_natural_pc(letter)?;
+    let acc: i16 = cs.fold(0i16, |a, ch| match ch {
+        '#' => a + 1,
+        'b' => a - 1,
+        _ => a,
+    });
+    let pc = (nat as i16 + acc).rem_euclid(12) as u8;
+    if pc != expect_m_abs {
+        return None;
+    }
+    Some(letter)
+}
+
+fn spell_letter_to_pc(letter: char, target_pc: u8) -> Option<&'static str> {
+    for &name in CHORD_STRINGS_SHARP
+        .iter()
+        .chain(CHORD_STRINGS_FLAT.iter())
+        .chain(CHORD_STRINGS_ENHARMONIC.iter())
+    {
+        if !name.starts_with(letter) {
+            continue;
+        }
+        let Ok(sc) = SimpleChord::try_from(name) else {
+            continue;
+        };
+        if sc.pitch_class() == target_pc {
+            return Some(name);
+        }
+    }
+    None
+}
+
+fn spell_slash_bass_from_intervals(
+    root_letter: char,
+    _m_abs: u8,
+    b_abs: u8,
+    interval: u8,
+) -> Option<&'static str> {
+    match interval {
+        0 => spell_letter_to_pc(root_letter, b_abs),
+        1 | 2 => {
+            let t = advance_diatonic_letter(root_letter, 1)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        3 | 4 => {
+            let t = advance_diatonic_letter(root_letter, 2)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        5 => {
+            let t = advance_diatonic_letter(root_letter, 3)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        6 => {
+            let fifth = advance_diatonic_letter(root_letter, 4)?;
+            if let Some(s) = spell_letter_to_pc(fifth, b_abs) {
+                return Some(s);
+            }
+            let fourth = advance_diatonic_letter(root_letter, 3)?;
+            spell_letter_to_pc(fourth, b_abs)
+        }
+        7 => {
+            let t = advance_diatonic_letter(root_letter, 4)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        8..=11 => {
+            let t = advance_diatonic_letter(root_letter, 5)?;
+            spell_letter_to_pc(t, b_abs)
+        }
+        _ => None,
     }
 }
 
@@ -161,10 +261,60 @@ impl SimpleChord {
     }
 }
 
+fn spell_root_diatonic_nominal(interval: u8, key: &SimpleChord, m_abs: u8) -> Option<&'static str> {
+    let interval = interval % 12;
+    let tonic_pc = key.level;
+    let tonic_display = SimpleChord::root_display_name(tonic_pc, key);
+    let tonic_letter = parse_root_nominal_letter(tonic_display, tonic_pc)?;
+    let diatonic_steps = match interval {
+        0 => 0,
+        1 | 2 => 1,
+        3 | 4 => 2,
+        5 => 3,
+        6 | 7 => 4,
+        8 | 9 => 5,
+        10 | 11 => 6,
+        _ => return None,
+    };
+    let letter = if diatonic_steps == 0 {
+        tonic_letter
+    } else {
+        advance_diatonic_letter(tonic_letter, diatonic_steps)?
+    };
+    spell_letter_to_pc(letter, m_abs)
+}
+
+/// Letter-name root when the main was parsed as a keyed Nashville numeral (e.g. `b7`).
+pub(crate) fn format_nashville_root_default(main: &SimpleChord, key: &SimpleChord) -> &'static str {
+    let m_abs = (main.level + key.level) % 12;
+    if main.level % 12 == 10
+        && let Some(s) = spell_root_diatonic_nominal(10, key, m_abs)
+    {
+        return s;
+    }
+    SimpleChord::root_display_name(m_abs, key)
+}
+
+/// Slash bass spelling for [`ChordRepresentation::Default`].
+pub(crate) fn format_slash_bass_default(
+    main: &SimpleChord,
+    base: &SimpleChord,
+    key: &SimpleChord,
+) -> &'static str {
+    let m_abs = main.combined_level(key);
+    let b_abs = base.combined_level(key);
+    let interval = (b_abs + 12 - m_abs) % 12;
+    let root_display = SimpleChord::root_display_name(m_abs, key);
+    let Some(root_letter) = parse_root_nominal_letter(root_display, m_abs) else {
+        return base.format(key, &ChordRepresentation::Default);
+    };
+    spell_slash_bass_from_intervals(root_letter, m_abs, b_abs, interval)
+        .unwrap_or_else(|| base.format(key, &ChordRepresentation::Default))
+}
+
 use serde::Deserializer;
 use serde_json::Value;
 
-use super::ChordRepresentation;
 fn float_or_int_to_int<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
Fixes incorrect `A#` output for Nashville **`b7`** in keys like **C** by spelling the lowered seventh with the diatonic letter (**`Bb`**).

### Approach
- Add `main_is_nashville_numeral` on [`Chord`](https://github.com/xilefmusics/chordlib/blob/fix/default-spelling-b7-b6/src/types/chord.rs) (serde default `false`), set when the root is parsed via the Nashville branch of `Chord::from_str_with_key`.
- For `ChordRepresentation::Default`, use [`format_nashville_root_default`](https://github.com/xilefmusics/chordlib/blob/fix/default-spelling-b7-b6/src/types/chord_simple.rs) so only true Nashville numerals get diatonic b7 spelling; letter chords and ChordPro transposition behavior stay unchanged.
- Clearing the flag on [`Chord::normalize`](https://github.com/xilefmusics/chordlib/blob/fix/default-spelling-b7-b6/src/types/chord.rs) avoids treating normalized intervals as “still Nashville” for display.
- Moved slash-bass spelling helpers into `chord_simple.rs` next to the shared tables.

### Limits
- Pitch class 9 is still a single stored value: `Gb` and `F#` share spelling for the tonic, so b7 follows that choice (`E` vs `Fb`); documented in tests.

Closes #58