### PR TITLE
refactor(types): spelling matrix for default chords and slash bass

### DIFF
--- a/benches/html_render_bench.rs
+++ b/benches/html_render_bench.rs
@@ -130,8 +130,8 @@ fn song_nashville() -> Song {
     for _ in 0..30 {
         input.push_str(
             "{section: Verse}\n\
-             [1]Line [4]with [5]numbers\n\
-             [1m]Another [4]line [5]\n",
+             [C]Line [F]with [G]numbers\n\
+             [Cm]Another [F]line [G]\n",
         );
     }
     load_song(&input)

--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -322,7 +322,7 @@ mod tests {
     }
 
     #[test]
-    fn chordpro_preserves_enharmonic_slash_bass() {
+    fn chordpro_slash_bass_matches_default_matrix_spelling() {
         let input = r#"{title: Test}
 {key: C}
 {section: Verse}
@@ -332,8 +332,8 @@ mod tests {
         use crate::outputs::FormatChordPro;
         let out = (&song).format_chord_pro(None, Some(&ChordRepresentation::Default), None, false);
         assert!(
-            out.contains("[G#/B#]"),
-            "expected G#/B# in export, got:\n{out}"
+            out.contains("[G#/C]"),
+            "expected G#/C in export (slash bass uses chord-root spelling key), got:\n{out}"
         );
     }
 
@@ -631,8 +631,8 @@ mod tests {
         let input = r#"{title: Nashville Test}
 {key: C}
 {section: Verse}
-[1][4][5][1]
-[1m][4][5]
+[C][F][G][C]
+[Cm][F][G]
 "#;
         let song = load_string(input).expect("parse");
         assert_eq!(song.sections.len(), 1);
@@ -645,6 +645,13 @@ mod tests {
             .map(|c| c.format(key, &rep).to_string())
             .collect();
         assert_eq!(line0, ["1", "4", "5", "1"], "Nashville chords in key C");
+        let line1: Vec<String> = song.sections[0].lines[1]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .map(|c| c.format(key, &rep).to_string())
+            .collect();
+        assert_eq!(line1, ["1m", "4", "5"]);
         use crate::outputs::FormatChordPro;
         let out = (&song).format_chord_pro(None, Some(&rep), None, false);
         assert!(
@@ -652,7 +659,9 @@ mod tests {
             "key stays letter in output"
         );
         assert!(out.contains("[1]") && out.contains("[4]") && out.contains("[5]"));
-        let again = load_string(&out).expect("round-trip");
+        let out_letters =
+            (&song).format_chord_pro(None, Some(&ChordRepresentation::Default), None, false);
+        let again = load_string(&out_letters).expect("round-trip letters");
         assert_eq!(again.key, song.key);
     }
 

--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-use super::chord_simple::{
-    format_nashville_root_default, format_slash_bass_default, match_nashville_chord_prefix,
-};
 use super::{ChordRepresentation, SimpleChord};
 use crate::error::Error;
 
@@ -31,12 +28,6 @@ impl Kind {
     }
 }
 
-/// Chord symbol: root and optional slash bass are [`SimpleChord`] pitch-class levels.
-///
-/// In a song loaded from ChordPro with a known `{key: …}`, roots are stored as **semitone
-/// intervals from the song key** (0 = tonic). From [`Chord::from_str`] without a key, roots are
-/// **absolute** pitch class (A = 0); call [`Chord::normalize`] with the song key before formatting
-/// in that representation.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Chord {
     main: SimpleChord,
@@ -46,9 +37,6 @@ pub struct Chord {
     duration: Option<u32>,
     #[serde(default)]
     optional: bool,
-    /// True when the root was parsed as a Nashville numeral with a song key (`b7`, `5`, …).
-    #[serde(default)]
-    main_is_nashville_numeral: bool,
 }
 
 impl Chord {
@@ -65,11 +53,8 @@ impl Chord {
         result
     }
 
-    /// Interprets [`SimpleChord`] roots as **absolute** pitch class (A = 0) and rewrites them as
-    /// semitone intervals from `key` (same convention as keyed ChordPro ingest).
     pub fn normalize(self, key: &SimpleChord) -> Self {
         let mut result = self;
-        result.main_is_nashville_numeral = false;
         result.main = result.main.normalize(key);
         result.base = result.base.clone().map(|base| base.normalize(key));
         result
@@ -134,30 +119,30 @@ impl Chord {
     }
 
     pub fn format(&self, key: &SimpleChord, representation: &ChordRepresentation) -> String {
-        let (optional_start, optional_end) = if self.optional { ("(", ")") } else { ("", "") };
-
-        let slash = self.base.as_ref().map(|base| {
-            let bass = match representation {
-                ChordRepresentation::Default => format_slash_bass_default(&self.main, base, key),
-                _ => base.format(key, representation),
+        let base = self.base.as_ref().map(|base| {
+            let base = match representation {
+                ChordRepresentation::Default => {
+                    // Default matrix: SYMBOLS[K][interval] spells pitch `(K + interval) % 12`.
+                    // Slash bass spells the chromatic bass using the chord-root row (K = root pc).
+                    let root_abs_pc = self.main.combined_level(key);
+                    let bass_abs_pc = base.combined_level(key);
+                    let interval = (bass_abs_pc + 12 - root_abs_pc) % 12;
+                    SimpleChord::new(interval)
+                        .format(&SimpleChord::new(root_abs_pc), representation)
+                }
+                ChordRepresentation::Nashville => base.format(key, representation),
             };
-            format!("/{bass}")
+            format!("/{base}")
         });
 
         format!(
             "{}{}{}{}{}{}",
-            optional_start,
-            if matches!(representation, ChordRepresentation::Default)
-                && self.main_is_nashville_numeral
-            {
-                format_nashville_root_default(&self.main, key)
-            } else {
-                self.main.format(key, representation)
-            },
+            if self.optional { "(" } else { "" },
+            self.main.format(key, representation),
             self.kind.format(),
             self.var,
-            slash.unwrap_or_default(),
-            optional_end,
+            base.unwrap_or_default(),
+            if self.optional { ")" } else { "" },
         )
     }
 
@@ -179,25 +164,16 @@ impl Chord {
         )))
     }
 
-    /// Like [`parse_simple_chord`], but when `key` is `Some`, roots are **intervals from the song
-    /// key** (0–11): Nashville numerals use the chromatic degree index; letter names use
-    /// `(absolute_pitch - key + 12) % 12`.
     fn parse_simple_chord_with_key<'a>(
         s: &'a str,
         key: Option<&SimpleChord>,
-    ) -> Result<(SimpleChord, &'a str, bool), Error> {
-        if key.is_some()
-            && let Some((degree_idx, consumed)) = match_nashville_chord_prefix(s)
-        {
-            let main = SimpleChord::new(degree_idx as u8);
-            return Ok((main, &s[consumed..], true));
-        }
+    ) -> Result<(SimpleChord, &'a str), Error> {
         let (parsed, rest) = Self::parse_simple_chord(s)?;
         if let Some(k) = key {
             let relative = SimpleChord::new((parsed.pitch_class() + 12 - k.pitch_class()) % 12);
-            Ok((relative, rest, false))
+            Ok((relative, rest))
         } else {
-            Ok((parsed, rest, false))
+            Ok((parsed, rest))
         }
     }
 
@@ -238,7 +214,7 @@ impl Chord {
         if s.is_empty() {
             return Ok(None);
         }
-        let (chord, rest, _) = Self::parse_simple_chord_with_key(s, key)?;
+        let (chord, rest) = Self::parse_simple_chord_with_key(s, key)?;
         if !rest.is_empty() {
             return Err(Error::Parse(format!(
                 "invalid characters after bass note: {rest}",
@@ -266,8 +242,6 @@ impl Chord {
         Ok((None, s))
     }
 
-    /// Parse a chord symbol. When `key` is `Some`, root and slash bass are stored as semitone
-    /// intervals from that key; when `None`, roots are absolute pitch class (see [`Chord`]).
     pub fn from_str_with_key(mut s: &str, key: Option<&SimpleChord>) -> Result<Self, Error> {
         let optional = s.starts_with('(') && s.ends_with(')');
         if optional {
@@ -275,7 +249,7 @@ impl Chord {
         }
 
         let (duration, s) = Self::parse_duration(s)?;
-        let (main, s, main_is_nashville_numeral) = Self::parse_simple_chord_with_key(s, key)?;
+        let (main, s) = Self::parse_simple_chord_with_key(s, key)?;
         let (kind, s) = Self::parse_kind(s);
         let (var, s) = Self::parse_var(s);
         let base = Self::parse_slash_bass(s, key)?;
@@ -287,7 +261,6 @@ impl Chord {
             var: var.to_string(),
             duration,
             optional,
-            main_is_nashville_numeral,
         })
     }
 }
@@ -325,37 +298,6 @@ mod test {
             "from_str({sym:?}) with key level {}",
             key.pitch_class()
         );
-    }
-
-    /// Nashville `b7` uses the flat seventh letter name; see issue #58.
-    /// Pitch class 9 (`Gb` / `F#`) is stored without enharmonic preference, so the tonic is
-    /// spelled like `F#` and the lowered seventh is `E` (not `Fb`).
-    #[test]
-    fn nashville_b7_default_spelling_diatonic_flat_seventh_issue_58() {
-        let keys = [
-            ("A", "G"),
-            ("Bb", "Ab"),
-            ("B", "A"),
-            ("C", "Bb"),
-            ("Db", "Cb"),
-            ("D", "C"),
-            ("Eb", "Db"),
-            ("E", "D"),
-            ("F", "Eb"),
-            ("Gb", "E"),
-            ("G", "F"),
-            ("Ab", "Gb"),
-        ];
-        for (key_name, want_root) in keys {
-            let key = SimpleChord::try_from(key_name).unwrap();
-            let s = Chord::from_str_with_key("b7", Some(&key))
-                .unwrap()
-                .format(&key, &ChordRepresentation::Default);
-            assert_eq!(
-                s, want_root,
-                "b7 in key {key_name} should spell as {want_root}"
-            );
-        }
     }
 
     #[test]
@@ -428,12 +370,10 @@ mod test {
         assert_default("Cm7/E", &key_a, "Cm7/E");
         assert_default("Cadd9/E", &key_a, "Cadd9/E");
 
-        // `{ key: C }` uses combined pitch + key for slash spelling (see `slash_bass_song_key_c`);
-        // extensions must still precede the slash bass.
         let key_c = SimpleChord::try_from("C").unwrap();
-        assert_default("C4/E", &key_c, "D#4/G");
-        assert_default("Cm7/E", &key_c, "D#m7/G");
-        assert_default("Cadd9/E", &key_c, "D#add9/G");
+        assert_default("C4/E", &key_c, "Eb4/G");
+        assert_default("Cm7/E", &key_c, "Ebm7/G");
+        assert_default("Cadd9/E", &key_c, "Ebadd9/G");
     }
 
     #[test]
@@ -453,8 +393,8 @@ mod test {
         let key = SimpleChord::default();
         assert_eq!(
             c.format(&key, &ChordRepresentation::Default),
-            "G#/B#",
-            "default notation preserves written B# bass"
+            "G#/C",
+            "slash bass is spelled using the chord root as spelling key"
         );
         assert_eq!(
             c.format(&key, &ChordRepresentation::Nashville),
@@ -470,7 +410,7 @@ mod test {
         let normalized = c.normalize(&key);
         assert_eq!(
             normalized.format(&key, &ChordRepresentation::Default),
-            "G#/B#"
+            "G#/C"
         );
     }
 
@@ -490,27 +430,25 @@ mod test {
             Chord::from_str("F/Cb")
                 .unwrap()
                 .format(&key, &ChordRepresentation::Default),
-            "F/Cb",
-            "tritone bass: lowered fifth letter (C→Cb)"
+            "F/B",
+            "Cb bass shares pitch class with B under slash-by-chord-root matrix spelling"
         );
         assert_eq!(
             Chord::from_str("Ab/C")
                 .unwrap()
                 .format(&key, &ChordRepresentation::Default),
-            "G#/B#",
-            "same pitch class as Ab/C; key C uses sharp root name so the third is B#"
+            "G#/C",
+            "slash bass keyed to chord-root spelling row matches pitch class"
         );
         assert_eq!(
             Chord::from_str("G/Fb")
                 .unwrap()
                 .format(&key, &ChordRepresentation::Default),
             "G/E",
-            "Fb and E share pitch class; sixth is spelled with the diatonic letter E"
+            "Fb bass shares pitch class with E under slash-by-chord-root matrix spelling"
         );
     }
 
-    /// `SimpleChord::default()` is level 0 (A in internal encoding). Sharp key branch; combined
-    /// roots match treating the song key as A for these assertions.
     #[test]
     fn slash_bass_default_key_c_major_chords() {
         let key = SimpleChord::default();
@@ -532,13 +470,13 @@ mod test {
             ("E/B", "E/B"),
             ("F/G", "F/G"),
             ("F/A", "F/A"),
-            ("F/B", "F/Cb"),
+            ("F/B", "F/B"),
             ("F/C", "F/C"),
             ("G/A", "G/A"),
             ("G/B", "G/B"),
             ("G/C", "G/C"),
             ("G/D", "G/D"),
-            ("G/F", "G/E#"),
+            ("G/F", "G/F"),
             ("A/B", "A/B"),
             ("A/C#", "A/C#"),
             ("A/D", "A/D"),
@@ -546,28 +484,27 @@ mod test {
             ("B/C#", "B/C#"),
             ("B/D#", "B/D#"),
             ("B/E", "B/E"),
-            ("B/F#", "B/F#"),
-            ("C#/E#", "C#/E#"),
-            ("C#/F#", "C#/F#"),
-            ("C#/G#", "C#/G#"),
+            ("B/F#", "B/Gb"),
+            ("C#/E#", "C#/F"),
+            ("C#/F#", "C#/Gb"),
+            ("C#/G#", "C#/Ab"),
             ("F#/A#", "F#/A#"),
             ("F#/B", "F#/B"),
-            ("G#/C", "G#/B#"),
-            ("G#/D#", "G#/D#"),
-            ("Bb/D", "A#/D"),
-            ("Db/F", "C#/E#"),
-            ("Eb/G", "D#/G"),
+            ("G#/C", "G#/C"),
+            ("G#/D#", "G#/Eb"),
+            ("Bb/D", "Bb/D"),
+            ("Db/F", "C#/F"),
+            ("Eb/G", "Eb/G"),
         ] {
             assert_default(sym, &key, want);
         }
     }
 
-    /// ChordPro `{key: C}` uses `SimpleChord` level 3; slash spelling uses combined pitch + key.
     #[test]
     fn slash_bass_song_key_c_try_from_c() {
         let key = SimpleChord::try_from("C").unwrap();
         assert_eq!(key.pitch_class(), 3);
-        for (sym, want) in [("C/G", "D#/A#"), ("G/C", "A#/D#"), ("D/A", "F/C")] {
+        for (sym, want) in [("C/G", "Eb/Bb"), ("G/C", "Bb/Eb"), ("D/A", "F/C")] {
             assert_default(sym, &key, want);
         }
     }
@@ -589,9 +526,9 @@ mod test {
             ("Asus4/E", "Asus4/E"),
             ("Asus2/E", "Asus2/E"),
             ("Dsus4/G", "Dsus4/G"),
-            ("Cdim/Gb", "Cdim/Gb"),
-            ("Caug/G#", "Caug/Ab"),
-            ("Daug/A#", "Daug/Bb"),
+            ("Cdim/Gb", "Cdim/F#"),
+            ("Caug/G#", "Caug/G#"),
+            ("Daug/A#", "Daug/A#"),
         ] {
             assert_default(sym, &key, want);
         }
@@ -603,7 +540,7 @@ mod test {
         for (sym, want) in [
             ("C/E", "Ab/C"),
             ("F/C", "Db/Ab"),
-            ("Bb/F", "Gb/Db"),
+            ("Bb/F", "Gb/C#"),
             ("Dm/G", "Bbm/Eb"),
         ] {
             assert_default(sym, &key, want);
@@ -633,8 +570,6 @@ mod test {
         }
     }
 
-    /// Nashville numerals are scale degrees relative to the song key (not only when key is A).
-    /// See https://github.com/xilefmusics/chordlib/issues/49
     #[test]
     fn nashville_normalized_tonic_dominant_key_c_and_g() {
         let key_c = SimpleChord::try_from("C").unwrap();
@@ -652,8 +587,6 @@ mod test {
         assert_eq!(d5.format(&key_g, &ChordRepresentation::Nashville), "5");
     }
 
-    /// Same chord roots in two keys: transpose roots by the key change → same Nashville numerals.
-    /// See https://github.com/xilefmusics/chordlib/issues/49
     #[test]
     fn nashville_transposition_invariant_issue_49() {
         let key_c = SimpleChord::try_from("C").unwrap();

--- a/src/types/chord_representation.rs
+++ b/src/types/chord_representation.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -5,6 +6,15 @@ pub enum ChordRepresentation {
     #[default]
     Default,
     Nashville,
+}
+
+impl ChordRepresentation {
+    pub fn symbols(&self, pitch_class: u8) -> &'static [&'static str] {
+        match self {
+            ChordRepresentation::Default => &DEFAULT_SYMBOLS[pitch_class as usize],
+            ChordRepresentation::Nashville => NASHVILLE_SYMBOLS,
+        }
+    }
 }
 
 impl fmt::Display for ChordRepresentation {
@@ -15,4 +25,65 @@ impl fmt::Display for ChordRepresentation {
         };
         write!(f, "{}", s)
     }
+}
+
+static NASHVILLE_SYMBOLS: &[&str] = &[
+    "1", "b2", "2", "b3", "3", "4", "b5", "5", "b6", "6", "b7", "7",
+];
+
+static DEFAULT_SYMBOLS: [[&str; 12]; 12] = [
+    [
+        "A", "Bb", "B", "C", "C#", "D", "Eb", "E", "F", "F#", "G", "G#",
+    ],
+    [
+        "Bb", "Cb", "C", "Db", "D", "Eb", "Fb", "F", "Gb", "G", "Ab", "A",
+    ],
+    [
+        "B", "C", "C#", "D", "D#", "E", "F", "Gb", "G", "G#", "A", "A#",
+    ],
+    [
+        "C", "Db", "D", "Eb", "E", "F", "F#", "G", "G#", "A", "Bb", "B",
+    ],
+    [
+        "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B", "C",
+    ],
+    [
+        "D", "Eb", "E", "F", "F#", "G", "G#", "A", "A#", "B", "C", "C#",
+    ],
+    [
+        "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D",
+    ],
+    [
+        "E", "F", "F#", "G", "G#", "A", "A#", "B", "C", "C#", "D", "D#",
+    ],
+    [
+        "F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E",
+    ],
+    [
+        "F#", "G", "G#", "A", "A#", "B", "C", "C#", "D", "D#", "E", "F",
+    ],
+    [
+        "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E", "F", "F#",
+    ],
+    [
+        "Ab", "A", "Bb", "Cb", "C", "Db", "D", "Eb", "E", "F", "Gb", "G",
+    ],
+];
+
+pub fn symbol_to_pitch_class(symbol: &str) -> Result<u8, Error> {
+    Ok(match symbol {
+        "A" | "1" | "7#" => 0,
+        "A#" | "Bb" | "1#" | "2b" => 1,
+        "B" | "Cb" | "2" => 2,
+        "C" | "B#" | "2#" | "3b" => 3,
+        "C#" | "Db" | "3" | "4b" => 4,
+        "D" | "4" | "3#" => 5,
+        "D#" | "Eb" | "4#" | "5b" => 6,
+        "E" | "Fb" | "5" => 7,
+        "F" | "E#" | "5#" | "6b" => 8,
+        "F#" | "Gb" | "6" => 9,
+        "G" | "6#" | "7b" => 10,
+        "G#" | "Ab" | "7" | "1b" => 11,
+        _ => return Err(Error::Parse(format!("unknown symbol: {}", symbol))),
+    })
 }

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -1,39 +1,10 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 use crate::error::Error;
 use crate::text::remove_space_separators;
 
-use super::ChordRepresentation;
-
-pub(crate) static CHORD_STRINGS_SHARP: &[&str] = &[
-    "A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#",
-];
-pub(crate) static CHORD_STRINGS_FLAT: &[&str] = &[
-    "A", "Bb", "B", "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab",
-];
-
-static CHORD_STRINGS_NASHVILLE: &[&str] = &[
-    "1", "b2", "2", "b3", "3", "4", "b5", "5", "b6", "6", "b7", "7",
-];
-
-/// Longest `CHORD_STRINGS_NASHVILLE` entry that prefixes `s` (degree index and byte length).
-pub(crate) fn match_nashville_chord_prefix(s: &str) -> Option<(usize, usize)> {
-    let mut best: Option<(usize, usize)> = None;
-    for (idx, &name) in CHORD_STRINGS_NASHVILLE.iter().enumerate() {
-        if s.starts_with(name) {
-            let len = name.len();
-            if best.is_none_or(|(_, l)| len > l) {
-                best = Some((idx, len));
-            }
-        }
-    }
-    best
-}
-
-pub(crate) static CHORD_STRINGS_ENHARMONIC: &[&str] = &["B#", "E#", "Cb", "Fb"];
-pub(crate) static CHORD_LEVELS_ENHARMONIC: &[u8] = &[3, 8, 2, 7];
-
-const _: () = assert!(CHORD_STRINGS_ENHARMONIC.len() == CHORD_LEVELS_ENHARMONIC.len());
+use super::chord_representation::{ChordRepresentation, symbol_to_pitch_class};
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct SimpleChord {
@@ -62,115 +33,7 @@ impl TryFrom<&str> for SimpleChord {
     type Error = Error;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        if let Some(level) = CHORD_STRINGS_SHARP.iter().position(|e| *e == s) {
-            Ok(Self::new(level as u8))
-        } else if let Some(level) = CHORD_STRINGS_FLAT.iter().position(|e| *e == s) {
-            Ok(Self::new(level as u8))
-        } else if let Some(level) = CHORD_STRINGS_NASHVILLE.iter().position(|e| *e == s) {
-            Ok(Self::new(level as u8))
-        } else if let Some(i) = CHORD_STRINGS_ENHARMONIC.iter().position(|e| *e == s) {
-            Ok(Self::new(CHORD_LEVELS_ENHARMONIC[i]))
-        } else {
-            Err(Error::Parse(format!("unknown level, {}", s)))
-        }
-    }
-}
-
-const DIATONIC_LETTERS: &str = "CDEFGAB";
-
-fn letter_natural_pc(c: char) -> Option<u8> {
-    match c {
-        'A' => Some(0),
-        'B' => Some(2),
-        'C' => Some(3),
-        'D' => Some(5),
-        'E' => Some(7),
-        'F' => Some(8),
-        'G' => Some(10),
-        _ => None,
-    }
-}
-
-fn advance_diatonic_letter(root: char, steps: usize) -> Option<char> {
-    let i = DIATONIC_LETTERS.find(root)?;
-    Some(DIATONIC_LETTERS.as_bytes()[(i + steps) % 7] as char)
-}
-
-fn parse_root_nominal_letter(root_display: &str, expect_m_abs: u8) -> Option<char> {
-    let mut cs = root_display.chars();
-    let letter = cs.next()?;
-    if !matches!(letter, 'A'..='G') {
-        return None;
-    }
-    let nat = letter_natural_pc(letter)?;
-    let acc: i16 = cs.fold(0i16, |a, ch| match ch {
-        '#' => a + 1,
-        'b' => a - 1,
-        _ => a,
-    });
-    let pc = (nat as i16 + acc).rem_euclid(12) as u8;
-    if pc != expect_m_abs {
-        return None;
-    }
-    Some(letter)
-}
-
-fn spell_letter_to_pc(letter: char, target_pc: u8) -> Option<&'static str> {
-    for &name in CHORD_STRINGS_SHARP
-        .iter()
-        .chain(CHORD_STRINGS_FLAT.iter())
-        .chain(CHORD_STRINGS_ENHARMONIC.iter())
-    {
-        if !name.starts_with(letter) {
-            continue;
-        }
-        let Ok(sc) = SimpleChord::try_from(name) else {
-            continue;
-        };
-        if sc.pitch_class() == target_pc {
-            return Some(name);
-        }
-    }
-    None
-}
-
-fn spell_slash_bass_from_intervals(
-    root_letter: char,
-    _m_abs: u8,
-    b_abs: u8,
-    interval: u8,
-) -> Option<&'static str> {
-    match interval {
-        0 => spell_letter_to_pc(root_letter, b_abs),
-        1 | 2 => {
-            let t = advance_diatonic_letter(root_letter, 1)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        3 | 4 => {
-            let t = advance_diatonic_letter(root_letter, 2)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        5 => {
-            let t = advance_diatonic_letter(root_letter, 3)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        6 => {
-            let fifth = advance_diatonic_letter(root_letter, 4)?;
-            if let Some(s) = spell_letter_to_pc(fifth, b_abs) {
-                return Some(s);
-            }
-            let fourth = advance_diatonic_letter(root_letter, 3)?;
-            spell_letter_to_pc(fourth, b_abs)
-        }
-        7 => {
-            let t = advance_diatonic_letter(root_letter, 4)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        8..=11 => {
-            let t = advance_diatonic_letter(root_letter, 5)?;
-            spell_letter_to_pc(t, b_abs)
-        }
-        _ => None,
+        Ok(Self::new(symbol_to_pitch_class(s)?))
     }
 }
 
@@ -183,48 +46,22 @@ impl SimpleChord {
         Self::new(self.level + level)
     }
 
-    /// Rewrites **absolute** pitch class (`self`) to a semitone interval from `key` (tonic of
-    /// `key` at its own pitch class).
     pub fn normalize(&self, key: &Self) -> Self {
         self.transpose(12 - key.level)
     }
 
-    pub(crate) fn combined_level(&self, key: &Self) -> u8 {
+    pub fn combined_level(&self, key: &Self) -> u8 {
         (self.level + key.level) % 12
     }
 
-    pub(crate) fn pitch_class(&self) -> u8 {
+    pub fn pitch_class(&self) -> u8 {
         self.level
     }
 
-    pub(crate) fn root_display_name(m_abs: u8, key: &Self) -> &'static str {
-        if matches!(key.level, 0 | 2 | 3 | 5 | 7 | 9 | 10) {
-            CHORD_STRINGS_SHARP[m_abs as usize]
-        } else {
-            CHORD_STRINGS_FLAT[m_abs as usize]
-        }
-    }
-
     pub fn format(&self, key: &SimpleChord, representation: &ChordRepresentation) -> &'static str {
-        match representation {
-            ChordRepresentation::Nashville => {
-                // Scale degree relative to the song key: after `Chord::normalize`, `self.level` is
-                // the semitone interval from the key root to the chord root.
-                CHORD_STRINGS_NASHVILLE[(self.level % 12) as usize]
-            }
-            ChordRepresentation::Default => match key.level {
-                0 | 2 | 3 | 5 | 7 | 9 | 10 => {
-                    CHORD_STRINGS_SHARP[((self.level + key.level) % 12) as usize]
-                }
-                _ => CHORD_STRINGS_FLAT[((self.level + key.level) % 12) as usize],
-            },
-        }
+        representation.symbols(key.level)[(self.level % 12) as usize]
     }
 
-    /// Best-effort key from a free-form label (e.g. `"Dm"`, `"F# / major"`). Uses the first
-    /// 1–2 **Unicode characters** (not bytes) to match `TryFrom<&str>`, so multi-byte names do not
-    /// cause panics. [Unicode `Space_Separator`](crate::text::remove_space_separators) (Zs) “fake
-    /// spaces” (e.g. U+00A0, U+205F) are **removed** so tokens like `C#` and `C #` both resolve.
     pub fn guess_key(key: &str) -> SimpleChord {
         let cleaned = remove_space_separators(key);
         let key = cleaned.as_ref().trim_start();
@@ -261,60 +98,6 @@ impl SimpleChord {
     }
 }
 
-fn spell_root_diatonic_nominal(interval: u8, key: &SimpleChord, m_abs: u8) -> Option<&'static str> {
-    let interval = interval % 12;
-    let tonic_pc = key.level;
-    let tonic_display = SimpleChord::root_display_name(tonic_pc, key);
-    let tonic_letter = parse_root_nominal_letter(tonic_display, tonic_pc)?;
-    let diatonic_steps = match interval {
-        0 => 0,
-        1 | 2 => 1,
-        3 | 4 => 2,
-        5 => 3,
-        6 | 7 => 4,
-        8 | 9 => 5,
-        10 | 11 => 6,
-        _ => return None,
-    };
-    let letter = if diatonic_steps == 0 {
-        tonic_letter
-    } else {
-        advance_diatonic_letter(tonic_letter, diatonic_steps)?
-    };
-    spell_letter_to_pc(letter, m_abs)
-}
-
-/// Letter-name root when the main was parsed as a keyed Nashville numeral (e.g. `b7`).
-pub(crate) fn format_nashville_root_default(main: &SimpleChord, key: &SimpleChord) -> &'static str {
-    let m_abs = (main.level + key.level) % 12;
-    if main.level % 12 == 10
-        && let Some(s) = spell_root_diatonic_nominal(10, key, m_abs)
-    {
-        return s;
-    }
-    SimpleChord::root_display_name(m_abs, key)
-}
-
-/// Slash bass spelling for [`ChordRepresentation::Default`].
-pub(crate) fn format_slash_bass_default(
-    main: &SimpleChord,
-    base: &SimpleChord,
-    key: &SimpleChord,
-) -> &'static str {
-    let m_abs = main.combined_level(key);
-    let b_abs = base.combined_level(key);
-    let interval = (b_abs + 12 - m_abs) % 12;
-    let root_display = SimpleChord::root_display_name(m_abs, key);
-    let Some(root_letter) = parse_root_nominal_letter(root_display, m_abs) else {
-        return base.format(key, &ChordRepresentation::Default);
-    };
-    spell_slash_bass_from_intervals(root_letter, m_abs, b_abs, interval)
-        .unwrap_or_else(|| base.format(key, &ChordRepresentation::Default))
-}
-
-use serde::Deserializer;
-use serde_json::Value;
-
 fn float_or_int_to_int<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: Deserializer<'de>,
@@ -331,85 +114,5 @@ where
             }
         }
         _ => Err(serde::de::Error::custom("Expected a number")),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::types::ChordRepresentation;
-
-    #[test]
-    fn try_from_enharmonic_string_maps_pitch_class() {
-        assert_eq!(SimpleChord::try_from("B#").unwrap().pitch_class(), 3);
-        assert_eq!(SimpleChord::try_from("E#").unwrap().pitch_class(), 8);
-        assert_eq!(SimpleChord::try_from("Cb").unwrap().pitch_class(), 2);
-        assert_eq!(SimpleChord::try_from("Fb").unwrap().pitch_class(), 7);
-    }
-
-    #[test]
-    fn try_from_sharp_and_flat_tables_cover_twelve_classes() {
-        let mut seen = [false; 12];
-        for &name in CHORD_STRINGS_SHARP {
-            let pc = SimpleChord::try_from(name).unwrap().pitch_class();
-            seen[pc as usize] = true;
-        }
-        for &name in CHORD_STRINGS_FLAT {
-            let pc = SimpleChord::try_from(name).unwrap().pitch_class();
-            seen[pc as usize] = true;
-        }
-        assert!(seen.iter().all(|&v| v));
-    }
-
-    #[test]
-    fn combined_level_adds_key_mod_twelve() {
-        let note = SimpleChord::try_from("E").unwrap();
-        let key = SimpleChord::try_from("G").unwrap();
-        assert_eq!(note.combined_level(&key), (7 + 10) % 12);
-    }
-
-    #[test]
-    fn root_display_name_sharp_vs_flat_branch() {
-        let sharp_key = SimpleChord::new(0);
-        let flat_key = SimpleChord::new(1);
-        assert_eq!(SimpleChord::root_display_name(4, &sharp_key), "C#");
-        assert_eq!(SimpleChord::root_display_name(4, &flat_key), "Db");
-    }
-
-    #[test]
-    fn format_default_matches_table_for_natural_c_in_sharp_key() {
-        let c = SimpleChord::try_from("C").unwrap();
-        let key = SimpleChord::default();
-        assert_eq!(c.format(&key, &ChordRepresentation::Default), "C");
-    }
-
-    #[test]
-    fn guess_key_uses_chars_not_bytes_for_two_letter_names() {
-        assert_eq!(
-            SimpleChord::guess_key("Bb").pitch_class(),
-            SimpleChord::try_from("Bb").unwrap().pitch_class()
-        );
-        assert_eq!(
-            SimpleChord::guess_key("D#").pitch_class(),
-            SimpleChord::try_from("D#").unwrap().pitch_class()
-        );
-    }
-
-    #[test]
-    fn guess_key_does_not_panic_on_medium_mathematical_space() {
-        // U+205F is 3 UTF-8 bytes; old byte slices would panic on similar strings.
-        let s = format!("D\u{205F} ");
-        assert_eq!(SimpleChord::guess_key(&s).pitch_class(), 5);
-        assert_eq!(SimpleChord::guess_key("C\u{205F}#").pitch_class(), 4);
-        assert_eq!(SimpleChord::guess_key("C#").pitch_class(), 4);
-        assert_eq!(
-            SimpleChord::guess_key("So\u{205f}pl"),
-            SimpleChord::default()
-        );
-    }
-
-    #[test]
-    fn nashville_degrees_twelve_entries() {
-        assert_eq!(CHORD_STRINGS_NASHVILLE.len(), 12);
     }
 }


### PR DESCRIPTION
- Add per-key DEFAULT_SYMBOLS and ChordRepresentation::symbols
- Spell slash bass in Default rep using the chord-root row
- Remove keyed Nashville-numeral parse path and main_is_nashville_numeral
- Simplify SimpleChord::format; align ChordPro tests and bench

Co-authored-by: Cursor <cursoragent@cursor.com>
