### PR TITLE
chore(deps): update dependencies and add HTML CLI input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["chords", "lyrics", "guitar", "chordpro", "songs"]
 categories = ["multimedia::audio", "command-line-utilities"]
 
 [dependencies]
-clap = { version = "4.6.0", features = ["derive"], optional = true }
-scraper = { version = "0.25.0", optional = true }
+clap = { version = "4.6.1", features = ["derive"], optional = true }
+scraper = { version = "0.27.0", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-askama = "0.15.4"
+serde_json = "1.0.150"
+askama = "0.16.0"
 lazy_static = "1.5.0"
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use chordlib::types::{ChordRepresentation, SimpleChord};
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// The input song file (ChordPro)
+    /// The input song file (ChordPro, Worship Pro, or Ultimate Guitar HTML)
     pub input: String,
     /// A boolean flag if the song should be rendered to the stdout
     #[arg(short, long, default_value_t = false)]
@@ -42,6 +42,9 @@ fn main() -> Result<(), Error> {
         || args.input.ends_with(".chopro")
     {
         chordlib::inputs::chord_pro::load(&args.input)
+    } else if args.input.ends_with(".html") {
+        let html = std::fs::read_to_string(&args.input)?;
+        chordlib::inputs::ultimate_guitar::load_html(&html)
     } else {
         Err(Error::Other(format!(
             "unknown input format ({})",

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -125,10 +125,7 @@ impl FormatHTML for &Song {
             |template, section| template.section(section),
         );
 
-        (
-            page_template.render().unwrap(),
-            self.html_css(scale),
-        )
+        (page_template.render().unwrap(), self.html_css(scale))
     }
 
     fn format_html(


### PR DESCRIPTION
## Summary
- Bump direct dependencies: `clap` 4.6.1, `scraper` 0.27.0, `serde_json` 1.0.150, `askama` 0.16.0
- Add CLI support for Ultimate Guitar `.html` input files via the existing HTML parser
- Minor rustfmt touch-up in `render_song.rs`

## Test plan
- [x] `cargo test --all-features` (101 tests passed)
- [x] `cargo clippy --all-features -- -D warnings` (zero warnings)
- [x] `cargo doc --no-deps --all-features`