### PR TITLE
fix(html): split word spans at multi-byte whitespace

### DIFF
--- a/src/outputs/html/render_part.rs
+++ b/src/outputs/html/render_part.rs
@@ -50,7 +50,11 @@ pub fn render_part(
         }
 
         if let Some(start) = start_word_position {
-            let (before_start, after_start) = text.split_at(start + 1);
+            let after_whitespace = text[start..]
+                .chars()
+                .next()
+                .map_or(start + 1, |c| start + c.len_utf8());
+            let (before_start, after_start) = text.split_at(after_whitespace);
             text = after_start;
 
             result.push_str(before_start);

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -349,4 +349,19 @@ mod tests {
                 .collect::<String>()
         );
     }
+
+    /// U+2005 (FOUR-PER-EM SPACE) is Zs whitespace; splitting word spans must not assume
+    /// a single-byte space when the next chord follows immediately.
+    #[test]
+    fn html_four_per_em_space_inside_word_does_not_panic() {
+        let mid_space = '\u{2005}';
+        let input = format!("{{title: T}}\n{{key: C}}\n{{section: V}}\n[C]a{mid_space}b[D]c\n");
+        let song = load_string(&input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let html = (&song).format_html(None, Some(&rep), None, None);
+
+        assert!(html.contains(r#"<span class="chord">C</span>"#));
+        assert!(html.contains(r#"<span class="chord">D</span>"#));
+        assert!(html.contains("class=\"word\""));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix a panic in HTML line rendering when lyrics contain U+2005 (FOUR-PER-EM SPACE) as an internal word separator and the next chord follows immediately (e.g. `[C]a\u2005b[D]c`).
- Word-span splitting now advances past the full whitespace character instead of assuming a single-byte ASCII space.
- Add a regression test covering the U+2005 inside-word case.

## Test plan
- [x] `cargo test` (100 tests)
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo doc --no-deps`