### PR TITLE
feat(chords): accept German H as alias for B

### DIFF
--- a/src/inputs/chord_pro/mod.rs
+++ b/src/inputs/chord_pro/mod.rs
@@ -1022,4 +1022,26 @@ mod tests {
             .collect();
         assert_eq!(numeral_as_letters, letter_line);
     }
+
+    /// Worship Pro files may use German H / Hm instead of B / Bm.
+    #[test]
+    fn worship_pro_german_h_chords() {
+        let input = r#"{title: German}
+{key: G}
+{section: Verse}
+[G]Zeile mit [Hm]Akkord
+"#;
+        let song = load_string(input).expect("parse German H chords");
+        use crate::types::ChordRepresentation;
+
+        let key = song.key.as_ref().unwrap();
+        let default = ChordRepresentation::Default;
+        let chords: Vec<String> = song.sections[0].lines[0]
+            .parts
+            .iter()
+            .filter_map(|p| p.chord.as_ref())
+            .map(|c| c.format(key, &default).to_string())
+            .collect();
+        assert_eq!(chords, ["G", "Bm"]);
+    }
 }

--- a/src/types/chord.rs
+++ b/src/types/chord.rs
@@ -784,4 +784,24 @@ mod test {
             );
         }
     }
+
+    /// German notation uses H for English B (B natural); Hm is B minor.
+    #[test]
+    fn german_h_alias_parses_like_b() {
+        let key = SimpleChord::default();
+        let h = Chord::from_str("H").expect("parse H");
+        let b = Chord::from_str("B").unwrap();
+        assert_eq!(h, b);
+        assert_eq!(fmt_default("H", &key), "B");
+
+        let hm = Chord::from_str("Hm").expect("parse Hm");
+        let bm = Chord::from_str("Bm").unwrap();
+        assert_eq!(hm, bm);
+        assert_eq!(fmt_default("Hm", &key), "Bm");
+
+        let h_slash = Chord::from_str("G/H").expect("parse G/H");
+        let g_b = Chord::from_str("G/B").unwrap();
+        assert_eq!(h_slash, g_b);
+        assert_eq!(fmt_default("G/H", &key), "G/B");
+    }
 }

--- a/src/types/chord_representation.rs
+++ b/src/types/chord_representation.rs
@@ -188,7 +188,7 @@ pub fn symbol_to_pitch_class(symbol: &str) -> Result<u8, Error> {
     Ok(match symbol {
         "A" | "1" | "7#" => 0,
         "A#" | "Bb" | "1#" | "b2" => 1,
-        "B" | "Cb" | "2" => 2,
+        "B" | "H" | "Cb" | "2" => 2,
         "C" | "B#" | "2#" | "b3" => 3,
         "C#" | "Db" | "3" => 4,
         "D" | "4" | "3#" => 5,

--- a/src/types/chord_simple.rs
+++ b/src/types/chord_simple.rs
@@ -18,7 +18,7 @@ impl TryFrom<char> for SimpleChord {
     fn try_from(c: char) -> Result<Self, Self::Error> {
         match c {
             'A' => Ok(Self::new(0)),
-            'B' => Ok(Self::new(2)),
+            'B' | 'H' => Ok(Self::new(2)),
             'C' => Ok(Self::new(3)),
             'D' => Ok(Self::new(5)),
             'E' => Ok(Self::new(7)),


### PR DESCRIPTION
## Summary
- Parse German `H` and `Hm` chord symbols as English `B` / `Bm` (B natural only; `B` still means B♭, not remapped).
- Applies to Worship Pro / ChordPro imports, `{key: H}`, and slash-bass roots such as `G/H`.
- Rendered output continues to use English spellings (`B`, `Bm`).

## Test plan
- [x] `cargo test` (101 tests, including `german_h_alias_parses_like_b` and `worship_pro_german_h_chords`)
- [x] `cargo clippy --all-features -- -D warnings` (zero warnings)
- [x] `cargo check`
- [x] `cargo doc --no-deps`