### PR TITLE
[codex] add primary-language fallback for missing translations

### DIFF
--- a/src/outputs/chord_pro/render_part.rs
+++ b/src/outputs/chord_pro/render_part.rs
@@ -10,11 +10,7 @@ impl FormatChordPro for &Part {
         worship_pro_features: bool,
     ) -> String {
         let language = language.unwrap_or(0);
-        let lang_text = self
-            .languages
-            .get(language)
-            .map(|l| l.as_str())
-            .unwrap_or("");
+        let lang_text = self.text_for_language(language);
 
         let chord = self.chord.as_ref().map_or(String::new(), |chord| {
             format!(

--- a/src/outputs/chord_pro/render_section.rs
+++ b/src/outputs/chord_pro/render_section.rs
@@ -105,3 +105,28 @@ impl FormatChordPro for &Section {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inputs::chord_pro::load_string;
+    use crate::outputs::FormatChordPro;
+
+    #[test]
+    fn format_chord_pro_falls_back_to_primary_language_text() {
+        let input = r#"{title: Fallback}
+{key: C}
+{language: de}
+{language2: en}
+{section: Verse}
+[C]Hallo
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+
+        let rendered = (&song).format_chord_pro(None, Some(&rep), Some(1), false);
+
+        assert!(rendered.contains("Hallo"));
+        assert!(!rendered.contains("()"));
+    }
+}

--- a/src/outputs/html/render_line.rs
+++ b/src/outputs/html/render_line.rs
@@ -79,11 +79,7 @@ impl<'a> LineRenderer<'a> {
 
     fn update_next_part(&mut self) {
         self.next_part = self.parts.next().map(|p| {
-            let next_text = p
-                .languages
-                .get(self.language)
-                .map(String::as_str)
-                .unwrap_or("");
+            let next_text = p.text_for_language(self.language);
             let mut first = None;
             let mut last = None;
             let mut starts_with = false;

--- a/src/outputs/html/render_part.rs
+++ b/src/outputs/html/render_part.rs
@@ -25,8 +25,10 @@ pub fn render_part(
         result.push_str("<span class=\"part\">");
     }
 
-    if let Some(text) = part.languages.get(language).filter(|t| !t.is_empty()) {
-        let mut text = text.as_str();
+    let text = part.text_for_language(language);
+
+    if !text.is_empty() {
+        let mut text = text;
         text_chars = text.chars().count();
 
         if let Some(end) = end_word_position {

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -220,6 +220,25 @@ mod tests {
     }
 
     #[test]
+    fn format_html_sections_falls_back_to_primary_language_text() {
+        let input = r#"{title: Fallback}
+{key: C}
+{language: de}
+{language2: en}
+{section: Verse}
+[C]Hallo
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+
+        let (sections, _) = (&song).format_html_sections(None, Some(&rep), Some(1), None);
+
+        assert_eq!(sections.len(), 1);
+        assert!(sections[0].contains("Hallo"));
+        assert!(!sections[0].contains("<span class=\"text\"> </span>"));
+    }
+
+    #[test]
     fn single_title_used_for_all_languages() {
         let input = r#"{title: Single}
 {key: C}

--- a/src/outputs/outputline.rs
+++ b/src/outputs/outputline.rs
@@ -46,7 +46,7 @@ impl FormatOutputLines for &Line {
                     )
                 );
             }
-            text_line = format!("{}{}", text_line, part.languages[language]);
+            text_line = format!("{}{}", text_line, part.text_for_language(language));
         }
 
         let mut result = Vec::default();
@@ -90,5 +90,34 @@ impl FormatOutputLines for &Song {
             .iter()
             .flat_map(|section| section.format_output_lines(Some(key), representation, language))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::outputs::FormatRender;
+    use crate::types::{Line, Part, Section, Song};
+
+    #[test]
+    fn format_render_uses_primary_text_as_fallback_for_missing_language() {
+        let song = Song {
+            sections: vec![Section {
+                title: "Verse".to_string(),
+                lines: vec![Line {
+                    parts: vec![Part {
+                        chord: None,
+                        languages: vec!["Hallo".to_string()],
+                        comment: false,
+                    }],
+                }],
+                repeat_count: 1,
+            }],
+            ..Song::default()
+        };
+
+        let rendered = song.format_render(None, None, Some(1));
+
+        assert!(rendered.contains("Hallo"));
+        assert!(!rendered.contains("\x1b[32m\x1b[0m"));
     }
 }

--- a/src/types/part.rs
+++ b/src/types/part.rs
@@ -71,6 +71,20 @@ pub struct Part {
 }
 
 impl Part {
+    /// Returns the text for a language index, falling back to the first language.
+    ///
+    /// If the requested slot is missing or empty, the primary language (index 0)
+    /// is used instead. This keeps partially translated lines visible rather than
+    /// rendering them as blanks.
+    pub fn text_for_language(&self, language: usize) -> &str {
+        self.languages
+            .get(language)
+            .filter(|text| !text.is_empty())
+            .map(String::as_str)
+            .or_else(|| self.languages.first().map(String::as_str))
+            .unwrap_or("")
+    }
+
     pub fn move_chord_to_next_vowel(mut self, mut prev: Self) -> (Self, Self) {
         for language in 0..self.languages.len().min(prev.languages.len()) {
             let text = &self.languages[language];
@@ -182,5 +196,54 @@ impl TryFrom<(&str, &str)> for Part {
             languages: vec![value.1.to_string()],
             comment: false,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_for_language_uses_requested_language_when_present() {
+        let part = Part {
+            chord: None,
+            languages: vec!["Hallo".to_string(), "Hello".to_string()],
+            comment: false,
+        };
+
+        assert_eq!(part.text_for_language(1), "Hello");
+    }
+
+    #[test]
+    fn text_for_language_falls_back_to_primary_when_missing() {
+        let part = Part {
+            chord: None,
+            languages: vec!["Hallo".to_string()],
+            comment: false,
+        };
+
+        assert_eq!(part.text_for_language(1), "Hallo");
+    }
+
+    #[test]
+    fn text_for_language_falls_back_to_primary_when_requested_slot_is_empty() {
+        let part = Part {
+            chord: None,
+            languages: vec!["Hallo".to_string(), String::new()],
+            comment: false,
+        };
+
+        assert_eq!(part.text_for_language(1), "Hallo");
+    }
+
+    #[test]
+    fn text_for_language_returns_empty_when_no_text_exists() {
+        let part = Part {
+            chord: None,
+            languages: vec![String::new(), String::new()],
+            comment: false,
+        };
+
+        assert_eq!(part.text_for_language(1), "");
     }
 }


### PR DESCRIPTION
## What changed
- Added a `Part::text_for_language()` helper that falls back to the primary language when a requested translation slot is missing or empty.
- Updated HTML, ChordPro, and console rendering paths to use that fallback.
- Added tests covering the helper and the user-facing render paths.

## Why
Lines that were missing a translation used to render as blank in some outputs. This change keeps the primary-language text visible instead of dropping the line content.

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `cargo check`
- `cargo doc --no-deps`