### PR TITLE
[codex] release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## [0.12.1] — Primary-language fallback for missing translations
+
+### 🐛 Fixes
+
+- **Line translation fallback** — When a requested line translation is missing or empty, renderers now fall back to the primary language instead of dropping the text. (#65)
+
+---
+
 ## [0.12.0] — German H alias, CLI HTML input & HTML fix
 
 ### ✨ Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chordlib"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "Work with chord-and-lyrics songs: parse, transform, and render them to multiple formats"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Release 0.12.1 for the primary-language fallback fix. This updates the crate version and changelog to match the tagged release.