### PR TITLE
[codex] keep Worship Pro languages separate on export

### DIFF
--- a/src/outputs/chord_pro/render_part.rs
+++ b/src/outputs/chord_pro/render_part.rs
@@ -10,7 +10,11 @@ impl FormatChordPro for &Part {
         worship_pro_features: bool,
     ) -> String {
         let language = language.unwrap_or(0);
-        let lang_text = self.text_for_language(language);
+        let lang_text = if worship_pro_features {
+            self.text_for_language_exact(language)
+        } else {
+            self.text_for_language(language)
+        };
 
         let chord = self.chord.as_ref().map_or(String::new(), |chord| {
             format!(

--- a/src/outputs/chord_pro/render_section.rs
+++ b/src/outputs/chord_pro/render_section.rs
@@ -129,4 +129,26 @@ mod tests {
         assert!(rendered.contains("Hallo"));
         assert!(!rendered.contains("()"));
     }
+
+    #[test]
+    fn worship_pro_export_keeps_multilingual_lines_separate() {
+        let input = r#"{title: Ohne Titel}
+{key: A}
+{language: de}
+{language2: en}
+{section: Chorus}
+Zeile 1
+&Line 1
+Zeile 2
+Zeile 3
+&Line 3
+{comment: riff 1-2-3-4}"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+
+        let rendered = (&song).format_chord_pro(None, Some(&rep), None, true);
+        let expected = "{title: Ohne Titel}\n{key: A}\n{language: de}\n{language2: en}\n{section: Chorus}\nZeile 1\n&Line 1\nZeile 2\nZeile 3\n&Line 3\n{comment: riff 1-2-3-4}\n";
+
+        assert_eq!(rendered, expected);
+    }
 }

--- a/src/types/part.rs
+++ b/src/types/part.rs
@@ -85,6 +85,14 @@ impl Part {
             .unwrap_or("")
     }
 
+    /// Returns the text at the requested language index without fallback.
+    pub fn text_for_language_exact(&self, language: usize) -> &str {
+        self.languages
+            .get(language)
+            .map(String::as_str)
+            .unwrap_or("")
+    }
+
     pub fn move_chord_to_next_vowel(mut self, mut prev: Self) -> (Self, Self) {
         for language in 0..self.languages.len().min(prev.languages.len()) {
             let text = &self.languages[language];
@@ -245,5 +253,16 @@ mod tests {
         };
 
         assert_eq!(part.text_for_language(1), "");
+    }
+
+    #[test]
+    fn text_for_language_exact_does_not_fallback() {
+        let part = Part {
+            chord: None,
+            languages: vec!["Hallo".to_string()],
+            comment: false,
+        };
+
+        assert_eq!(part.text_for_language_exact(1), "");
     }
 }


### PR DESCRIPTION
## What changed
- Prevented Worship Pro export from applying the primary-language fallback to `&` translation lines.
- Added an exact-language helper so normal rendering can still fall back while Worship Pro export stays slot-accurate.
- Added a regression test using the reported multi-language example.

## Why
The previous fallback fix was correct for display rendering, but it corrupted Worship Pro round-trips by prefixing the base-language text into translated `&` lines.

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `cargo check`
- `cargo doc --no-deps`