### PR TITLE
[codex] keep HTML language selection from mixing translations

### DIFF
--- a/src/outputs/html/render_line.rs
+++ b/src/outputs/html/render_line.rs
@@ -10,51 +10,70 @@ struct LineRenderer<'a> {
     key: &'a SimpleChord,
     representation: &'a ChordRepresentation,
     language: usize,
+    use_primary_fallback: bool,
 }
 
 impl<'a> Iterator for LineRenderer<'a> {
     type Item = (String, String);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (part, first, last, _, ends_with) = self.next_part?;
-        self.update_next_part();
+        loop {
+            let (part, first, last, _, ends_with) = self.next_part?;
+            self.update_next_part();
 
-        let next_starts_with = self
-            .next_part
-            .is_some_and(|(_, _, _, starts_with, _)| starts_with);
+            let text = if self.use_primary_fallback {
+                part.text_for_language(self.language)
+            } else {
+                part.text_for_language_exact(self.language)
+            };
 
-        let inside_word = !ends_with && !next_starts_with && self.next_part.is_some();
+            if !self.use_primary_fallback
+                && text.is_empty()
+                && part.chord.is_none()
+                && !part.comment
+            {
+                self.inside_word = false;
+                continue;
+            }
 
-        let end = if self.inside_word && first.is_some() {
-            first
-        } else {
-            None
-        };
-        let start = if inside_word && last.is_some() {
-            last
-        } else {
-            None
-        };
+            let next_starts_with = self
+                .next_part
+                .is_some_and(|(_, _, _, starts_with, _)| starts_with);
 
-        self.inside_word = inside_word;
+            let inside_word = !ends_with && !next_starts_with && self.next_part.is_some();
 
-        let (part, text_chars, chord_chars) = render_part::render_part(
-            part,
-            self.key,
-            self.representation,
-            self.language,
-            start,
-            end,
-        );
+            let end = if self.inside_word && first.is_some() {
+                first
+            } else {
+                None
+            };
+            let start = if inside_word && last.is_some() {
+                last
+            } else {
+                None
+            };
 
-        Some((
-            part,
-            Self::suffix(
-                self.next_part.is_some(),
-                inside_word,
-                chord_chars as i32 - text_chars as i32 + 1,
-            ),
-        ))
+            self.inside_word = inside_word;
+
+            let (part, text_chars, chord_chars) = render_part::render_part(
+                part,
+                self.key,
+                self.representation,
+                self.language,
+                self.use_primary_fallback,
+                start,
+                end,
+            );
+
+            return Some((
+                part,
+                Self::suffix(
+                    self.next_part.is_some(),
+                    inside_word,
+                    chord_chars as i32 - text_chars as i32 + 1,
+                ),
+            ));
+        }
     }
 }
 
@@ -65,6 +84,13 @@ impl<'a> LineRenderer<'a> {
         representation: &'a ChordRepresentation,
         language: usize,
     ) -> Self {
+        // If this line contains any text for the requested language, render that exact
+        // translation and skip empty primary-only parts. Otherwise fall back to the primary.
+        let use_primary_fallback = !line
+            .parts
+            .iter()
+            .any(|part| !part.text_for_language_exact(language).is_empty());
+
         let mut s = Self {
             parts: line.parts.iter(),
             next_part: None,
@@ -72,6 +98,7 @@ impl<'a> LineRenderer<'a> {
             key,
             representation,
             language,
+            use_primary_fallback,
         };
         s.update_next_part();
         s
@@ -79,7 +106,11 @@ impl<'a> LineRenderer<'a> {
 
     fn update_next_part(&mut self) {
         self.next_part = self.parts.next().map(|p| {
-            let next_text = p.text_for_language(self.language);
+            let next_text = if self.use_primary_fallback {
+                p.text_for_language(self.language)
+            } else {
+                p.text_for_language_exact(self.language)
+            };
             let mut first = None;
             let mut last = None;
             let mut starts_with = false;

--- a/src/outputs/html/render_part.rs
+++ b/src/outputs/html/render_part.rs
@@ -5,6 +5,7 @@ pub fn render_part(
     key: &SimpleChord,
     representation: &ChordRepresentation,
     language: usize,
+    use_primary_fallback: bool,
     mut start_word_position: Option<usize>,
     end_word_position: Option<usize>,
 ) -> (String, usize, usize) {
@@ -25,7 +26,11 @@ pub fn render_part(
         result.push_str("<span class=\"part\">");
     }
 
-    let text = part.text_for_language(language);
+    let text = if use_primary_fallback {
+        part.text_for_language(language)
+    } else {
+        part.text_for_language_exact(language)
+    };
 
     if !text.is_empty() {
         let mut text = text;

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -239,6 +239,32 @@ mod tests {
     }
 
     #[test]
+    fn format_html_sections_prefers_exact_translation_when_present_on_line() {
+        let input = r#"{title: Ohne Titel}
+{key: A}
+{language: de}
+{language2: en}
+{section: Chorus}
+Zeile 1
+&Line 1
+Zeile 2
+Zeile 3
+&Line 3
+{comment: riff 1-2-3-4}
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+
+        let (sections, _) = (&song).format_html_sections(None, Some(&rep), Some(1), None);
+
+        assert_eq!(sections.len(), 1);
+        assert!(sections[0].contains("Line 1"), "{}", sections[0]);
+        assert!(sections[0].contains("Line 3"), "{}", sections[0]);
+        assert!(!sections[0].contains("Zeile 1Line 1"), "{}", sections[0]);
+        assert!(!sections[0].contains("Zeile 3Line 3"), "{}", sections[0]);
+    }
+
+    #[test]
     fn single_title_used_for_all_languages() {
         let input = r#"{title: Single}
 {key: C}


### PR DESCRIPTION
## What changed
- Updated HTML line rendering so it uses exact-language text when a line contains a translation for the selected language.
- Preserves primary-language fallback only when the whole line is untranslated in the requested language.
- Skips empty text-only parts in exact-translation mode so translated lines do not get stitched together with phantom hyphens or split words.
- Added a regression test for the reported `Zeile 1` / `&Line 1` example.

## Why
The previous fallback fix was correct for display rendering in general, but HTML selection still mixed the base language into translated lines. That produced output like `Zeile 1Line 1` or split word fragments when the second language was selected.

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `cargo check`
- `cargo doc --no-deps`