### PR TITLE
feat(song): add custom song flow rendering

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ pub enum Error {
     Filesystem(String),
     Serialize(String),
     Http(String),
+    InvalidSongFlow(String),
     Other(String),
 }
 
@@ -18,6 +19,7 @@ impl fmt::Display for Error {
             Self::Filesystem(message) => write!(f, "FilesystemError ({})", message),
             Self::Serialize(message) => write!(f, "Serialize ({})", message),
             Self::Http(message) => write!(f, "Http ({})", message),
+            Self::InvalidSongFlow(message) => write!(f, "InvalidSongFlow ({})", message),
             Self::Other(message) => write!(f, "{}", message),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Error> {
     if args.render {
         println!(
             "{}",
-            song.format_render(None, representation.as_ref(), args.language)
+            song.format_render(None, representation.as_ref(), args.language, None)?
         );
     }
 
@@ -86,7 +86,7 @@ fn main() -> Result<(), Error> {
     } else if args.output.ends_with(".html") {
         Ok(std::fs::write(
             args.output,
-            (&song).format_html(None, representation.as_ref(), args.language, None),
+            (&song).format_html(None, representation.as_ref(), args.language, None, None)?,
         )?)
     } else if args.output.is_empty() {
         Ok(())

--- a/src/outputs/charpage.rs
+++ b/src/outputs/charpage.rs
@@ -1,5 +1,6 @@
-use super::{FormatOutputLines, OutputLine};
-use crate::types::{ChordRepresentation, SimpleChord, Song};
+use super::{FormatOutputLines, OutputLine, repeat_label};
+use crate::Error;
+use crate::types::{ChordRepresentation, SimpleChord, Song, SongFlowItem};
 use std::cmp::max;
 use std::iter::{Chain, Repeat, Take, Zip};
 use std::slice::Iter;
@@ -170,7 +171,8 @@ pub trait FormatCharPages {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> Vec<CharPage>;
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<CharPage>, Error>;
 }
 
 impl FormatCharPages for &Song {
@@ -181,21 +183,26 @@ impl FormatCharPages for &Song {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> Vec<CharPage> {
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<CharPage>, Error> {
         let mut char_pages = vec![CharPage::new(max_width, max_height)];
+        let (sections, custom_flow) = self.sections_for_flow(flow)?;
 
-        for section in &self.sections {
-            let lines = char_pages.last_mut().unwrap().try_add_lines(
-                section
-                    .format_output_lines(key, representation, language)
-                    .into_iter()
-                    .map(|line| match line {
-                        OutputLine::Keyword(s) => CharPageLine::Keyword(s),
-                        OutputLine::Chord(s) => CharPageLine::Chord(s),
-                        OutputLine::Text(s) => CharPageLine::Text(s),
-                    })
-                    .collect(),
-            );
+        for section in sections {
+            let mut lines: Vec<CharPageLine> = (&section)
+                .format_output_lines(key, representation, language, None)?
+                .into_iter()
+                .map(|line| match line {
+                    OutputLine::Keyword(s) => CharPageLine::Keyword(s),
+                    OutputLine::Chord(s) => CharPageLine::Chord(s),
+                    OutputLine::Text(s) => CharPageLine::Text(s),
+                })
+                .collect();
+            if custom_flow && let Some(repeat_text) = repeat_label(section.repeat_count) {
+                lines.push(CharPageLine::Text(repeat_text));
+            }
+
+            let lines = char_pages.last_mut().unwrap().try_add_lines(lines);
 
             if !lines.is_empty() {
                 let mut new_char_page = CharPage::new(max_width, max_height);
@@ -204,6 +211,63 @@ impl FormatCharPages for &Song {
             }
         }
 
-        char_pages
+        Ok(char_pages)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inputs::chord_pro::load_string;
+    use crate::types::SongFlowItem;
+
+    fn flow_item(title: &str, repeats: u32) -> SongFlowItem {
+        SongFlowItem {
+            title: title.to_string(),
+            repeats,
+        }
+    }
+
+    #[test]
+    fn format_char_pages_supports_custom_flow_and_empty_flow_matches_default() {
+        let input = r#"{title: Ohne Titel}
+{key: A}
+{section: Tag 1}
+Text 1
+{section: Tag 2}
+Text 2
+{section: Tag 3}
+Text 3
+{section: Tag 1}
+{section: Tag 2}
+{section: Tag 3}
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let flow = vec![
+            flow_item("Tag 1", 1),
+            flow_item("Tag 2", 1),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 1", 2),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 2", 1),
+        ];
+
+        let default_pages = (&song)
+            .format_char_pages(80, 20, None, Some(&rep), None, None)
+            .expect("render");
+        let empty_flow_pages = (&song)
+            .format_char_pages(80, 20, None, Some(&rep), None, Some(&[]))
+            .expect("render");
+        assert_eq!(default_pages.len(), empty_flow_pages.len());
+
+        let custom_pages = (&song)
+            .format_char_pages(80, 20, None, Some(&rep), None, Some(&flow))
+            .expect("render");
+        let rendered = custom_pages[0].render(&CharPageSet::new());
+        assert!(rendered.contains("Tag 1:"));
+        assert!(rendered.contains("Text 1"));
+        assert!(rendered.contains("(repeat)"));
+        assert!(rendered.contains("Tag 3:"));
     }
 }

--- a/src/outputs/html/format_html.rs
+++ b/src/outputs/html/format_html.rs
@@ -1,4 +1,5 @@
-use crate::types::{ChordRepresentation, SimpleChord};
+use crate::Error;
+use crate::types::{ChordRepresentation, SimpleChord, SongFlowItem};
 
 pub trait FormatHTML {
     fn format_html(
@@ -7,14 +8,16 @@ pub trait FormatHTML {
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
         scale: Option<f32>,
-    ) -> String;
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<String, Error>;
     fn format_html_page(
         &self,
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
         scale: Option<f32>,
-    ) -> (String, String);
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<(String, String), Error>;
     /// Render each song section as HTML (`<p><span class="keyword">…</span>…</p>`).
     /// Returns `(section_htmls, css)` — no `.page` wrapper, header, or footer.
     fn format_html_sections(
@@ -23,5 +26,6 @@ pub trait FormatHTML {
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
         scale: Option<f32>,
-    ) -> (Vec<String>, String);
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<(Vec<String>, String), Error>;
 }

--- a/src/outputs/html/render_section.rs
+++ b/src/outputs/html/render_section.rs
@@ -123,7 +123,9 @@ mod tests {
     #[test]
     fn html_does_not_show_repeat_marker_for_default() {
         let song = make_song_with_section("Chorus", 1);
-        let html = (&song).format_html(None, Some(&ChordRepresentation::Default), None, None);
+        let html = (&song)
+            .format_html(None, Some(&ChordRepresentation::Default), None, None, None)
+            .expect("render");
 
         assert!(html.contains("<span class=\"keyword\">Chorus</span>"));
         assert!(!html.contains("(repeat"));
@@ -132,7 +134,9 @@ mod tests {
     #[test]
     fn html_shows_repeat_marker_for_section_with_repeat_count() {
         let song = make_song_with_section("Chorus", 2);
-        let html = (&song).format_html(None, Some(&ChordRepresentation::Default), None, None);
+        let html = (&song)
+            .format_html(None, Some(&ChordRepresentation::Default), None, None, None)
+            .expect("render");
 
         assert!(html.contains("<span class=\"comment\">(repeat)</span>"));
     }

--- a/src/outputs/html/render_song.rs
+++ b/src/outputs/html/render_song.rs
@@ -1,5 +1,6 @@
 use super::{CssTemplate, FormatHTML, HtmlPageTemplate, HtmlTemplate, render_section};
-use crate::types::{ChordRepresentation, SimpleChord, Song};
+use crate::Error;
+use crate::types::{ChordRepresentation, SimpleChord, Song, SongFlowItem};
 use askama::Template;
 
 struct HtmlRenderContext {
@@ -40,8 +41,13 @@ impl Song {
         (ctx, key_str)
     }
 
-    fn render_section_htmls(&self, ctx: &HtmlRenderContext) -> Vec<String> {
-        self.sections
+    fn render_section_htmls(
+        &self,
+        ctx: &HtmlRenderContext,
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<String>, Error> {
+        let (sections, _) = self.sections_for_flow(flow)?;
+        Ok(sections
             .iter()
             .map(|section| {
                 render_section::render_section(
@@ -54,7 +60,7 @@ impl Song {
                     ctx.compact_six_eight,
                 )
             })
-            .collect()
+            .collect())
     }
 
     fn html_css(&self, scale: Option<f32>) -> String {
@@ -73,11 +79,12 @@ impl FormatHTML for &Song {
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
         scale: Option<f32>,
-    ) -> (Vec<String>, String) {
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<(Vec<String>, String), Error> {
         let (ctx, _) = self.html_render_context(key, representation, language);
-        let sections = self.render_section_htmls(&ctx);
+        let sections = self.render_section_htmls(&ctx, flow)?;
         let css = self.html_css(scale);
-        (sections, css)
+        Ok((sections, css))
     }
 
     fn format_html_page(
@@ -86,10 +93,11 @@ impl FormatHTML for &Song {
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
         scale: Option<f32>,
-    ) -> (String, String) {
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<(String, String), Error> {
         let language = language.unwrap_or(0);
         let (ctx, key_str) = self.html_render_context(key, representation, Some(language));
-        let section_htmls = self.render_section_htmls(&ctx);
+        let section_htmls = self.render_section_htmls(&ctx, flow)?;
 
         let selected_artist = self.artist_slice().and_then(|list| {
             let idx = language;
@@ -114,8 +122,9 @@ impl FormatHTML for &Song {
         };
 
         let display_title = self.title_for_language(Some(language));
+        let section_count = section_htmls.len();
         let page_template = section_htmls.into_iter().fold(
-            HtmlPageTemplate::with_capacity(self.sections.len())
+            HtmlPageTemplate::with_capacity(section_count)
                 .title(display_title)
                 .subtitle(&subtitle)
                 .key(&key_str)
@@ -125,7 +134,7 @@ impl FormatHTML for &Song {
             |template, section| template.section(section),
         );
 
-        (page_template.render().unwrap(), self.html_css(scale))
+        Ok((page_template.render().unwrap(), self.html_css(scale)))
     }
 
     fn format_html(
@@ -134,9 +143,10 @@ impl FormatHTML for &Song {
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
         scale: Option<f32>,
-    ) -> String {
-        let (page, style) = self.format_html_page(key, representation, language, scale);
-        wrap_html(&page, &style, self.title_for_language(language))
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<String, Error> {
+        let (page, style) = self.format_html_page(key, representation, language, scale, flow)?;
+        Ok(wrap_html(&page, &style, self.title_for_language(language)))
     }
 }
 
@@ -153,6 +163,14 @@ pub fn wrap_html(html: &str, css: &str, title: &str) -> String {
 mod tests {
     use super::*;
     use crate::inputs::chord_pro::load_string;
+    use crate::types::SongFlowItem;
+
+    fn flow_item(title: &str, repeats: u32) -> SongFlowItem {
+        SongFlowItem {
+            title: title.to_string(),
+            repeats,
+        }
+    }
 
     fn extract_tag(html: &str, tag: &str) -> Option<String> {
         let start = format!("<{tag}");
@@ -176,7 +194,9 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let (sections, css) = (&song).format_html_sections(None, Some(&rep), None, None);
+        let (sections, css) = (&song)
+            .format_html_sections(None, Some(&rep), None, None, None)
+            .expect("render");
         assert_eq!(sections.len(), 2);
         assert!(sections[0].contains("<span class=\"keyword\">Verse</span>"));
         assert!(sections[1].contains("<span class=\"keyword\">Chorus</span>"));
@@ -192,7 +212,9 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let (sections, css) = (&song).format_html_sections(None, Some(&rep), None, None);
+        let (sections, css) = (&song)
+            .format_html_sections(None, Some(&rep), None, None, None)
+            .expect("render");
         assert!(sections.is_empty());
         assert!(!css.is_empty());
     }
@@ -209,9 +231,12 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let (section_htmls, css_sections) =
-            (&song).format_html_sections(None, Some(&rep), None, None);
-        let (page_html, css_page) = (&song).format_html_page(None, Some(&rep), None, None);
+        let (section_htmls, css_sections) = (&song)
+            .format_html_sections(None, Some(&rep), None, None, None)
+            .expect("render");
+        let (page_html, css_page) = (&song)
+            .format_html_page(None, Some(&rep), None, None, None)
+            .expect("render");
 
         for section in &section_htmls {
             assert!(page_html.contains(section.as_str()));
@@ -231,8 +256,12 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let html_lang0 = (&song).format_html(None, Some(&rep), None, None);
-        let html_lang1 = (&song).format_html(None, Some(&rep), Some(1), None);
+        let html_lang0 = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
+        let html_lang1 = (&song)
+            .format_html(None, Some(&rep), Some(1), None, None)
+            .expect("render");
 
         // <title> tag
         assert_eq!(extract_tag(&html_lang0, "title").as_deref(), Some("Single"));
@@ -258,9 +287,15 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let html_lang0 = (&song).format_html(None, Some(&rep), None, None);
-        let html_lang1 = (&song).format_html(None, Some(&rep), Some(1), None);
-        let html_lang2 = (&song).format_html(None, Some(&rep), Some(2), None);
+        let html_lang0 = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
+        let html_lang1 = (&song)
+            .format_html(None, Some(&rep), Some(1), None, None)
+            .expect("render");
+        let html_lang2 = (&song)
+            .format_html(None, Some(&rep), Some(2), None, None)
+            .expect("render");
 
         // Language 0: first title
         assert_eq!(
@@ -305,8 +340,12 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let html_lang0 = (&song).format_html(None, Some(&rep), None, None);
-        let html_lang1 = (&song).format_html(None, Some(&rep), Some(1), None);
+        let html_lang0 = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
+        let html_lang1 = (&song)
+            .format_html(None, Some(&rep), Some(1), None, None)
+            .expect("render");
 
         assert!(html_lang0.contains("Nur Deutsch"));
         assert!(html_lang0.contains("Auch nur Deutsch"));
@@ -335,8 +374,12 @@ Zeile 3
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let html_de = (&song).format_html(None, Some(&rep), None, None);
-        let html_en = (&song).format_html(None, Some(&rep), Some(1), None);
+        let html_de = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
+        let html_en = (&song)
+            .format_html(None, Some(&rep), Some(1), None, None)
+            .expect("render");
 
         assert!(html_de.contains("Zeile 1"));
         assert!(html_de.contains("Zeile 2"));
@@ -361,7 +404,9 @@ Zeile 3
 "#;
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
-        let html = (&song).format_html(None, Some(&rep), None, None);
+        let html = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
 
         assert!(
             html.contains(r#"<span class="chord">C</span>"#),
@@ -387,7 +432,9 @@ Zeile 3
 "#;
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
-        let html = (&song).format_html(None, Some(&rep), None, None);
+        let html = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
 
         assert!(
             html.contains(r#"<span class="chord">F</span><span class="bar">|</span></span></p>"#),
@@ -419,10 +466,72 @@ Zeile 3
         let input = format!("{{title: T}}\n{{key: C}}\n{{section: V}}\n[C]a{mid_space}b[D]c\n");
         let song = load_string(&input).expect("parse");
         let rep = ChordRepresentation::Default;
-        let html = (&song).format_html(None, Some(&rep), None, None);
+        let html = (&song)
+            .format_html(None, Some(&rep), None, None, None)
+            .expect("render");
 
         assert!(html.contains(r#"<span class="chord">C</span>"#));
         assert!(html.contains(r#"<span class="chord">D</span>"#));
         assert!(html.contains("class=\"word\""));
+    }
+
+    #[test]
+    fn html_custom_flow_renders_first_body_then_empty_references() {
+        let input = r#"{title: Ohne Titel}
+{key: A}
+{section: Tag 1}
+Text 1
+{section: Tag 2}
+Text 2
+{section: Tag 3}
+Text 3
+{section: Tag 1}
+{section: Tag 2}
+{section: Tag 3}
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let flow = vec![
+            flow_item("Tag 1", 1),
+            flow_item("Tag 2", 1),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 1", 2),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 2", 1),
+        ];
+
+        let (sections, css) = (&song)
+            .format_html_sections(None, Some(&rep), None, None, Some(&flow))
+            .expect("render");
+        assert_eq!(sections.len(), 6);
+        assert!(sections[0].contains("Text 1"));
+        assert!(sections[3].contains("(repeat)"));
+        assert!(!sections[3].contains("Text 1"));
+        assert!(sections[4].contains(r#"<span class="keyword">Tag 3</span><br>"#));
+        assert!(!sections[4].contains("Text 3"));
+        assert!(!css.is_empty());
+
+        let page = (&song)
+            .format_html(None, Some(&rep), None, None, Some(&flow))
+            .expect("render");
+        assert!(page.contains("Text 1"));
+        assert!(page.contains("(repeat)"));
+    }
+
+    #[test]
+    fn html_custom_flow_rejects_unknown_titles() {
+        let input = r#"{title: Test}
+{key: C}
+{section: Verse}
+Line
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let flow = vec![flow_item("Missing", 1)];
+
+        let err = (&song)
+            .format_html_sections(None, Some(&rep), None, None, Some(&flow))
+            .expect_err("flow should fail");
+        assert!(matches!(err, crate::Error::InvalidSongFlow(_)));
     }
 }

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -7,5 +7,6 @@ mod render;
 pub use charpage::{CharPage, CharPageSet, FormatCharPages};
 pub use chord_pro::FormatChordPro;
 pub use html::{FormatHTML, render_section, wrap_html};
+pub(crate) use outputline::repeat_label;
 pub use outputline::{FormatOutputLines, OutputLine};
 pub use render::FormatRender;

--- a/src/outputs/outputline.rs
+++ b/src/outputs/outputline.rs
@@ -1,4 +1,5 @@
-use crate::types::{ChordRepresentation, Line, Section, SimpleChord, Song};
+use crate::Error;
+use crate::types::{ChordRepresentation, Line, Section, SimpleChord, Song, SongFlowItem};
 
 pub enum OutputLine {
     Keyword(String),
@@ -12,7 +13,8 @@ pub trait FormatOutputLines {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> Vec<OutputLine>;
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<OutputLine>, Error>;
 }
 
 impl FormatOutputLines for &Line {
@@ -21,7 +23,8 @@ impl FormatOutputLines for &Line {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> Vec<OutputLine> {
+        _flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<OutputLine>, Error> {
         let mut chord_line = String::default();
         let mut text_line = String::default();
         let language = language.unwrap_or(0);
@@ -56,7 +59,7 @@ impl FormatOutputLines for &Line {
         if !text_line.is_empty() {
             result.push(OutputLine::Text(text_line));
         }
-        result
+        Ok(result)
     }
 }
 
@@ -66,14 +69,13 @@ impl FormatOutputLines for &Section {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> Vec<OutputLine> {
-        std::iter::once(OutputLine::Keyword(self.title.clone()))
-            .chain(
-                self.lines
-                    .iter()
-                    .flat_map(|line| line.format_output_lines(key, representation, language)),
-            )
-            .collect()
+        _flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<OutputLine>, Error> {
+        let mut output = vec![OutputLine::Keyword(self.title.clone())];
+        for line in &self.lines {
+            output.extend(line.format_output_lines(key, representation, language, None)?);
+        }
+        Ok(output)
     }
 }
 
@@ -83,13 +85,34 @@ impl FormatOutputLines for &Song {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> Vec<OutputLine> {
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<Vec<OutputLine>, Error> {
         let self_key = self.key.clone().unwrap_or_default();
         let key = key.unwrap_or(&self_key);
-        self.sections
-            .iter()
-            .flat_map(|section| section.format_output_lines(Some(key), representation, language))
-            .collect()
+        let (sections, custom_flow) = self.sections_for_flow(flow)?;
+        let mut output = Vec::new();
+
+        for section in sections {
+            output.extend((&section).format_output_lines(
+                Some(key),
+                representation,
+                language,
+                None,
+            )?);
+            if custom_flow && let Some(repeat_text) = repeat_label(section.repeat_count) {
+                output.push(OutputLine::Text(repeat_text));
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+pub(crate) fn repeat_label(repeat_count: u32) -> Option<String> {
+    match repeat_count {
+        0 | 1 => None,
+        2 => Some("(repeat)".to_string()),
+        repeats => Some(format!("(repeat {}x)", repeats)),
     }
 }
 
@@ -98,6 +121,14 @@ mod tests {
     use super::*;
     use crate::inputs::chord_pro::load_string;
     use crate::types::ChordRepresentation;
+    use crate::types::SongFlowItem;
+
+    fn flow_item(title: &str, repeats: u32) -> SongFlowItem {
+        SongFlowItem {
+            title: title.to_string(),
+            repeats,
+        }
+    }
 
     #[test]
     fn format_output_lines_partial_translation_falls_back_to_primary_language() {
@@ -113,8 +144,12 @@ mod tests {
         let song = load_string(input).expect("parse");
         let rep = ChordRepresentation::Default;
 
-        let lines_lang0 = (&song.sections[0]).format_output_lines(None, Some(&rep), None);
-        let lines_lang1 = (&song.sections[0]).format_output_lines(None, Some(&rep), Some(1));
+        let lines_lang0 = (&song.sections[0])
+            .format_output_lines(None, Some(&rep), None, None)
+            .expect("render");
+        let lines_lang1 = (&song.sections[0])
+            .format_output_lines(None, Some(&rep), Some(1), None)
+            .expect("render");
 
         let text_lang0: Vec<&str> = lines_lang0
             .iter()
@@ -133,5 +168,81 @@ mod tests {
 
         assert_eq!(text_lang0, vec!["Nur Deutsch", "Auch nur Deutsch"]);
         assert_eq!(text_lang1, vec!["Only English", "Auch nur Deutsch"]);
+    }
+
+    #[test]
+    fn format_output_lines_supports_custom_flow_and_empty_flow_matches_default() {
+        let input = r#"{title: Ohne Titel}
+{key: A}
+{section: Tag 1}
+Text 1
+{section: Tag 2}
+Text 2
+{section: Tag 3}
+Text 3
+{section: Tag 1}
+{section: Tag 2}
+{section: Tag 3}
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let flow = vec![
+            flow_item("Tag 1", 1),
+            flow_item("Tag 2", 1),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 1", 2),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 2", 1),
+        ];
+
+        let default_lines = (&song)
+            .format_output_lines(None, Some(&rep), None, None)
+            .expect("render");
+        let empty_flow_lines = (&song)
+            .format_output_lines(None, Some(&rep), None, Some(&[]))
+            .expect("render");
+        assert_eq!(default_lines.len(), empty_flow_lines.len());
+        assert_eq!(
+            default_lines
+                .iter()
+                .map(|line| match line {
+                    OutputLine::Keyword(s) | OutputLine::Chord(s) | OutputLine::Text(s) => s,
+                })
+                .collect::<Vec<&String>>(),
+            empty_flow_lines
+                .iter()
+                .map(|line| match line {
+                    OutputLine::Keyword(s) | OutputLine::Chord(s) | OutputLine::Text(s) => s,
+                })
+                .collect::<Vec<&String>>()
+        );
+
+        let custom_lines = (&song)
+            .format_output_lines(None, Some(&rep), None, Some(&flow))
+            .expect("render");
+        let text = custom_lines
+            .iter()
+            .map(|line| match line {
+                OutputLine::Keyword(s) => format!("K:{s}"),
+                OutputLine::Chord(s) => format!("C:{s}"),
+                OutputLine::Text(s) => format!("T:{s}"),
+            })
+            .collect::<Vec<String>>();
+
+        assert_eq!(
+            text,
+            vec![
+                "K:Tag 1",
+                "T:Text 1",
+                "K:Tag 2",
+                "T:Text 2",
+                "K:Tag 3",
+                "T:Text 3",
+                "K:Tag 1",
+                "T:(repeat)",
+                "K:Tag 3",
+                "K:Tag 2",
+            ]
+        );
     }
 }

--- a/src/outputs/render.rs
+++ b/src/outputs/render.rs
@@ -1,5 +1,6 @@
 use super::{FormatOutputLines, OutputLine};
-use crate::types::{ChordRepresentation, SimpleChord, Song};
+use crate::Error;
+use crate::types::{ChordRepresentation, SimpleChord, Song, SongFlowItem};
 
 pub trait FormatRender {
     fn format_render(
@@ -7,7 +8,8 @@ pub trait FormatRender {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> String;
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<String, Error>;
 }
 
 impl FormatRender for Song {
@@ -16,8 +18,10 @@ impl FormatRender for Song {
         key: Option<&SimpleChord>,
         representation: Option<&ChordRepresentation>,
         language: Option<usize>,
-    ) -> String {
-        self.format_output_lines(key, representation, language)
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<String, Error> {
+        let lines = self.format_output_lines(key, representation, language, flow)?;
+        Ok(lines
             .iter()
             .map(|line| match line {
                 OutputLine::Keyword(keyword) => format!("\x1b[31;1m{}\x1b[0m", keyword),
@@ -25,6 +29,61 @@ impl FormatRender for Song {
                 OutputLine::Text(text) => format!("\x1b[32m{}\x1b[0m", text),
             })
             .collect::<Vec<String>>()
-            .join("\n")
+            .join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inputs::chord_pro::load_string;
+    use crate::types::SongFlowItem;
+
+    fn flow_item(title: &str, repeats: u32) -> SongFlowItem {
+        SongFlowItem {
+            title: title.to_string(),
+            repeats,
+        }
+    }
+
+    #[test]
+    fn format_render_supports_custom_flow_and_empty_flow_matches_default() {
+        let input = r#"{title: Ohne Titel}
+{key: A}
+{section: Tag 1}
+Text 1
+{section: Tag 2}
+Text 2
+{section: Tag 3}
+Text 3
+{section: Tag 1}
+{section: Tag 2}
+{section: Tag 3}
+"#;
+        let song = load_string(input).expect("parse");
+        let rep = ChordRepresentation::Default;
+        let flow = vec![
+            flow_item("Tag 1", 1),
+            flow_item("Tag 2", 1),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 1", 2),
+            flow_item("Tag 3", 1),
+            flow_item("Tag 2", 1),
+        ];
+
+        let default_render = song
+            .format_render(None, Some(&rep), None, None)
+            .expect("render");
+        let empty_flow_render = song
+            .format_render(None, Some(&rep), None, Some(&[]))
+            .expect("render");
+        assert_eq!(default_render, empty_flow_render);
+
+        let custom_render = song
+            .format_render(None, Some(&rep), None, Some(&flow))
+            .expect("render");
+        assert!(custom_render.contains("\x1b[31;1mTag 1\x1b[0m"));
+        assert!(custom_render.contains("\x1b[32mText 1\x1b[0m"));
+        assert!(custom_render.contains("\x1b[32m(repeat)\x1b[0m"));
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,4 +12,4 @@ pub use chord_simple::SimpleChord;
 pub use line::Line;
 pub use part::Part;
 pub use section::Section;
-pub use song::{Song, chord_duration_to_layout_milliclicks};
+pub use song::{Song, SongFlowItem, chord_duration_to_layout_milliclicks};

--- a/src/types/song.rs
+++ b/src/types/song.rs
@@ -1,8 +1,10 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use super::{Section, SimpleChord};
+use crate::Error;
+
+use super::{Line, Section, SimpleChord};
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Song {
@@ -25,6 +27,18 @@ pub struct Song {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub tags: BTreeMap<String, String>,
     pub sections: Vec<Section>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct SongFlowItem {
+    pub title: String,
+    pub repeats: u32,
+}
+
+impl PartialEq<&str> for SongFlowItem {
+    fn eq(&self, other: &&str) -> bool {
+        self.title == *other
+    }
 }
 
 impl Song {
@@ -111,6 +125,92 @@ impl Song {
         self
     }
 
+    /// Returns the distinct section names in first-seen order.
+    ///
+    /// Sections are grouped by exact title. Empty sections only establish the
+    /// base title, while later non-empty variants may receive numeric suffixes
+    /// like ` [2]` when their content differs.
+    pub fn distinct_section_names(&self) -> Vec<String> {
+        let mut resolver = SectionNameResolver::new(self);
+        let mut distinct = Vec::new();
+
+        for section in &self.sections {
+            let resolution = resolver.resolve(section);
+            if resolution.is_new {
+                distinct.push(resolution.name);
+            }
+        }
+
+        distinct
+    }
+
+    /// Returns the section labels for the full flow of the song, preserving
+    /// every section occurrence in order.
+    pub fn section_flow_names(&self) -> Vec<SongFlowItem> {
+        let mut resolver = SectionNameResolver::new(self);
+        let mut flow = Vec::with_capacity(self.sections.len());
+
+        for section in &self.sections {
+            let resolution = resolver.resolve(section);
+            flow.push(SongFlowItem {
+                title: resolution.name,
+                repeats: section.repeat_count,
+            });
+        }
+
+        flow
+    }
+
+    pub(crate) fn sections_for_flow(
+        &self,
+        flow: Option<&[SongFlowItem]>,
+    ) -> Result<(Vec<Section>, bool), Error> {
+        let Some(flow) = flow.filter(|flow| !flow.is_empty()) else {
+            return Ok((self.sections.clone(), false));
+        };
+
+        let mut resolver = SectionNameResolver::new(self);
+        let mut distinct_sections = BTreeMap::new();
+
+        for section in &self.sections {
+            let resolution = resolver.resolve(section);
+            let title = resolution.name;
+            distinct_sections.entry(title.clone()).or_insert_with(|| {
+                let mut distinct_section = section.clone();
+                distinct_section.title = title.clone();
+                distinct_section
+            });
+        }
+
+        let mut rendered_sections = Vec::with_capacity(flow.len());
+        let mut seen_titles = BTreeSet::new();
+
+        for item in flow {
+            if item.repeats < 1 {
+                return Err(Error::InvalidSongFlow(format!(
+                    "repeat count for section {:?} must be at least 1",
+                    item.title
+                )));
+            }
+
+            let Some(template) = distinct_sections.get(&item.title) else {
+                return Err(Error::InvalidSongFlow(format!(
+                    "unknown section title {:?}",
+                    item.title
+                )));
+            };
+
+            let mut section = template.clone();
+            section.repeat_count = item.repeats;
+            if !seen_titles.insert(item.title.clone()) {
+                section.lines.clear();
+            }
+            rendered_sections.push(section);
+        }
+
+        Ok((rendered_sections, true))
+    }
+
     /// Returns a slice of artists when `artists` is non-empty.
     pub fn artist_slice(&self) -> Option<&[String]> {
         if self.artists.is_empty() {
@@ -152,9 +252,179 @@ pub fn chord_duration_to_layout_milliclicks(
     }
 }
 
+#[derive(Default)]
+struct SectionTitleState<'a> {
+    variants: Vec<SectionVariant<'a>>,
+    emitted_base: bool,
+    next_suffix: usize,
+}
+
+struct SectionVariant<'a> {
+    lines: &'a [Line],
+    name: String,
+}
+
+struct SectionNameResolution {
+    name: String,
+    is_new: bool,
+}
+
+struct SectionNameResolver<'a> {
+    literal_titles: BTreeSet<&'a str>,
+    states: BTreeMap<&'a str, SectionTitleState<'a>>,
+    used_names: BTreeSet<String>,
+}
+
+impl<'a> SectionNameResolver<'a> {
+    fn new(song: &'a Song) -> Self {
+        Self {
+            literal_titles: song
+                .sections
+                .iter()
+                .map(|section| section.title.as_str())
+                .collect(),
+            states: BTreeMap::new(),
+            used_names: BTreeSet::new(),
+        }
+    }
+
+    fn resolve(&mut self, section: &'a Section) -> SectionNameResolution {
+        let title = section.title.as_str();
+        let state = self.states.entry(title).or_default();
+
+        if section.lines.is_empty() {
+            let is_new = !state.emitted_base;
+            if is_new {
+                state.emitted_base = true;
+                let name = title.to_string();
+                self.used_names.insert(name.clone());
+                return SectionNameResolution { name, is_new };
+            }
+
+            return SectionNameResolution {
+                name: title.to_string(),
+                is_new,
+            };
+        }
+
+        if let Some(existing) = state
+            .variants
+            .iter()
+            .find(|variant| variant.lines == section.lines.as_slice())
+        {
+            return SectionNameResolution {
+                name: existing.name.clone(),
+                is_new: false,
+            };
+        }
+
+        let is_first_non_empty_variant = state.variants.is_empty();
+        if is_first_non_empty_variant {
+            state.variants.push(SectionVariant {
+                lines: section.lines.as_slice(),
+                name: title.to_string(),
+            });
+
+            if !state.emitted_base {
+                state.emitted_base = true;
+                let name = title.to_string();
+                self.used_names.insert(name.clone());
+                return SectionNameResolution { name, is_new: true };
+            }
+
+            return SectionNameResolution {
+                name: title.to_string(),
+                is_new: false,
+            };
+        }
+
+        let mut suffix = state.next_suffix.max(2);
+        let name = loop {
+            let candidate = format!("{title} [{suffix}]");
+            if !self.literal_titles.contains(candidate.as_str())
+                && !self.used_names.contains(&candidate)
+            {
+                break candidate;
+            }
+            suffix += 1;
+        };
+
+        state.next_suffix = suffix + 1;
+        state.variants.push(SectionVariant {
+            lines: section.lines.as_slice(),
+            name: name.clone(),
+        });
+        self.used_names.insert(name.clone());
+
+        SectionNameResolution { name, is_new: true }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Error;
+    use crate::types::{Chord, Line, Part, Section};
+    use std::str::FromStr;
+
+    fn text_part(text: &str) -> Part {
+        Part {
+            chord: None,
+            languages: vec![text.to_string()],
+            comment: false,
+        }
+    }
+
+    fn chord_part(chord: &str, text: &str) -> Part {
+        Part {
+            chord: Some(Chord::from_str(chord).unwrap()),
+            languages: vec![text.to_string()],
+            comment: false,
+        }
+    }
+
+    fn comment_part(text: &str) -> Part {
+        Part {
+            chord: None,
+            languages: vec![text.to_string()],
+            comment: true,
+        }
+    }
+
+    fn multilingual_part(texts: &[&str]) -> Part {
+        Part {
+            chord: None,
+            languages: texts.iter().map(|text| (*text).to_string()).collect(),
+            comment: false,
+        }
+    }
+
+    fn text_line(text: &str) -> Line {
+        Line::new(vec![text_part(text)])
+    }
+
+    fn chord_line(chord: &str, text: &str) -> Line {
+        Line::new(vec![chord_part(chord, text)])
+    }
+
+    fn comment_line(text: &str) -> Line {
+        Line::new(vec![comment_part(text)])
+    }
+
+    fn section(title: &str, lines: Vec<Line>) -> Section {
+        Section::new(title.to_string(), lines)
+    }
+
+    fn section_with_repeat(title: &str, lines: Vec<Line>, repeat_count: u32) -> Section {
+        Section::new_with_repeat(title.to_string(), lines, repeat_count)
+    }
+
+    fn flow_item(title: &str, repeats: u32) -> SongFlowItem {
+        SongFlowItem {
+            title: title.to_string(),
+            repeats,
+        }
+    }
 
     #[test]
     fn primary_getters_return_empty_when_vectors_empty() {
@@ -292,5 +562,594 @@ mod tests {
         };
         assert_eq!(song.title_for_language(None), "");
         assert_eq!(song.title_for_language(Some(1)), "OnlySecond");
+    }
+
+    #[test]
+    fn distinct_section_names_returns_empty_for_song_without_sections() {
+        let song = Song::default();
+        assert!(song.distinct_section_names().is_empty());
+    }
+
+    #[test]
+    fn distinct_section_names_returns_single_name_for_single_section() {
+        let song = Song {
+            sections: vec![section("Chorus", vec![text_line("This is the content")])],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Chorus"]);
+    }
+
+    #[test]
+    fn distinct_section_names_collapses_exact_duplicate_sections_and_keeps_first_order() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("This is the content")]),
+                section("Chorus", vec![text_line("This is the content")]),
+                section(
+                    "Chorus",
+                    vec![text_line("This is the content, but different")],
+                ),
+                section("Chorus", vec![text_line("This is the content")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Chorus", "Chorus [2]"]);
+    }
+
+    #[test]
+    fn distinct_section_names_ignores_repeat_count_when_contents_match() {
+        let song = Song {
+            sections: vec![
+                section_with_repeat("Verse", vec![text_line("Same line")], 1),
+                section_with_repeat("Verse", vec![text_line("Same line")], 4),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Verse"]);
+    }
+
+    #[test]
+    fn distinct_section_names_treats_empty_sections_as_one_name_only() {
+        let song = Song {
+            sections: vec![
+                section("Intro", vec![]),
+                section("Intro", vec![]),
+                section("Intro", vec![]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Intro"]);
+    }
+
+    #[test]
+    fn distinct_section_names_keeps_unsuffixed_name_when_empty_precedes_content() {
+        let song = Song {
+            sections: vec![
+                section("Bridge", vec![]),
+                section("Bridge", vec![text_line("First content")]),
+                section("Bridge", vec![text_line("First content")]),
+                section("Bridge", vec![text_line("Second content")]),
+                section("Bridge", vec![]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Bridge", "Bridge [2]"]);
+    }
+
+    #[test]
+    fn distinct_section_names_handles_empty_sections_between_content_variants() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("Alpha")]),
+                section("Chorus", vec![]),
+                section("Chorus", vec![text_line("Beta")]),
+                section("Chorus", vec![]),
+                section("Chorus", vec![text_line("Beta")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Chorus", "Chorus [2]"]);
+    }
+
+    #[test]
+    fn distinct_section_names_compares_sections_structurally_across_line_details() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Same text")]),
+                section("Verse", vec![chord_line("C", "Same text")]),
+                section("Verse", vec![comment_line("Same text")]),
+                section(
+                    "Verse",
+                    vec![Line::new(vec![text_part("Same"), text_part(" text")])],
+                ),
+                section(
+                    "Verse",
+                    vec![Line::new(vec![text_part("Same text"), text_part(" extra")])],
+                ),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.distinct_section_names(),
+            vec!["Verse", "Verse [2]", "Verse [3]", "Verse [4]", "Verse [5]"]
+        );
+    }
+
+    #[test]
+    fn distinct_section_names_treats_translation_changes_as_distinct() {
+        let song = Song {
+            sections: vec![
+                section(
+                    "Verse",
+                    vec![Line::new(vec![multilingual_part(&["Deutsch", "English"])])],
+                ),
+                section(
+                    "Verse",
+                    vec![Line::new(vec![multilingual_part(&["Deutsch", "Français"])])],
+                ),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Verse", "Verse [2]"]);
+    }
+
+    #[test]
+    fn distinct_section_names_treats_line_count_changes_as_distinct() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("One")]),
+                section("Verse", vec![text_line("One"), text_line("Two")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Verse", "Verse [2]"]);
+    }
+
+    #[test]
+    fn distinct_section_names_treats_different_line_order_as_distinct() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("One"), text_line("Two")]),
+                section("Verse", vec![text_line("Two"), text_line("One")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Verse", "Verse [2]"]);
+    }
+
+    #[test]
+    fn distinct_section_names_keeps_same_content_under_different_titles_separate() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Shared")]),
+                section("Chorus", vec![text_line("Shared")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.distinct_section_names(), vec!["Verse", "Chorus"]);
+    }
+
+    #[test]
+    fn distinct_section_names_skips_collisions_with_literal_suffixed_titles() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("Alpha")]),
+                section("Chorus [2]", vec![text_line("Literal two")]),
+                section("Chorus", vec![text_line("Beta")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.distinct_section_names(),
+            vec!["Chorus", "Chorus [2]", "Chorus [3]"]
+        );
+    }
+
+    #[test]
+    fn distinct_section_names_skips_future_literal_collisions_when_numbering_variants() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("Alpha")]),
+                section("Chorus", vec![text_line("Beta")]),
+                section("Chorus [2]", vec![text_line("Literal two")]),
+                section("Chorus [3]", vec![text_line("Literal three")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.distinct_section_names(),
+            vec!["Chorus", "Chorus [4]", "Chorus [2]", "Chorus [3]"]
+        );
+    }
+
+    #[test]
+    fn distinct_section_names_skips_multiple_occupied_suffixes() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Alpha")]),
+                section("Verse [2]", vec![text_line("Literal two")]),
+                section("Verse [3]", vec![text_line("Literal three")]),
+                section("Verse", vec![text_line("Beta")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.distinct_section_names(),
+            vec!["Verse", "Verse [2]", "Verse [3]", "Verse [4]"]
+        );
+    }
+
+    #[test]
+    fn distinct_section_names_is_case_sensitive_and_handles_empty_titles() {
+        let song = Song {
+            sections: vec![
+                section("", vec![text_line("Blank title content")]),
+                section("", vec![text_line("Different blank title content")]),
+                section("chorus", vec![text_line("lowercase")]),
+                section("Chorus", vec![text_line("uppercase")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.distinct_section_names(),
+            vec!["", " [2]", "chorus", "Chorus"]
+        );
+    }
+
+    #[test]
+    fn distinct_section_names_does_not_mutate_song() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Alpha")]),
+                section("Verse", vec![text_line("Beta")]),
+                section("Verse [2]", vec![text_line("Literal two")]),
+            ],
+            ..Song::default()
+        };
+        let original = song.clone();
+
+        let names = song.distinct_section_names();
+
+        assert_eq!(song, original);
+        assert_eq!(names, vec!["Verse", "Verse [3]", "Verse [2]"]);
+    }
+
+    #[test]
+    fn section_flow_names_returns_empty_for_song_without_sections() {
+        let song = Song::default();
+        assert!(song.section_flow_names().is_empty());
+    }
+
+    #[test]
+    fn section_flow_names_returns_single_name_for_single_section() {
+        let song = Song {
+            sections: vec![section("Chorus", vec![text_line("This is the content")])],
+            ..Song::default()
+        };
+
+        assert_eq!(song.section_flow_names(), vec!["Chorus"]);
+    }
+
+    #[test]
+    fn section_flow_names_reuses_name_for_exact_duplicate_sections() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("This is the content")]),
+                section("Chorus", vec![text_line("This is the content")]),
+                section(
+                    "Chorus",
+                    vec![text_line("This is the content, but different")],
+                ),
+                section("Chorus", vec![text_line("This is the content")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Chorus", "Chorus", "Chorus [2]", "Chorus"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_ignores_repeat_count_when_contents_match() {
+        let song = Song {
+            sections: vec![
+                section_with_repeat("Verse", vec![text_line("Same line")], 1),
+                section_with_repeat("Verse", vec![text_line("Same line")], 4),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec![flow_item("Verse", 1), flow_item("Verse", 4)]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_copies_repeat_counts_for_default_flow() {
+        let song = Song {
+            sections: vec![
+                section_with_repeat("Verse", vec![text_line("One")], 2),
+                section_with_repeat("Chorus", vec![text_line("Two")], 3),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec![flow_item("Verse", 2), flow_item("Chorus", 3)]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_keeps_empty_sections_in_flow_without_creating_variants() {
+        let song = Song {
+            sections: vec![
+                section("Intro", vec![]),
+                section("Intro", vec![]),
+                section("Intro", vec![text_line("First content")]),
+                section("Intro", vec![]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Intro", "Intro", "Intro", "Intro"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_keeps_unsuffixed_name_when_empty_precedes_content() {
+        let song = Song {
+            sections: vec![
+                section("Bridge", vec![]),
+                section("Bridge", vec![text_line("First content")]),
+                section("Bridge", vec![text_line("First content")]),
+                section("Bridge", vec![text_line("Second content")]),
+                section("Bridge", vec![]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Bridge", "Bridge", "Bridge", "Bridge [2]", "Bridge"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_handles_empty_sections_between_content_variants() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("Alpha")]),
+                section("Chorus", vec![]),
+                section("Chorus", vec![text_line("Beta")]),
+                section("Chorus", vec![]),
+                section("Chorus", vec![text_line("Beta")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Chorus", "Chorus", "Chorus [2]", "Chorus", "Chorus [2]"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_compares_sections_structurally_across_line_details() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Same text")]),
+                section("Verse", vec![chord_line("C", "Same text")]),
+                section("Verse", vec![comment_line("Same text")]),
+                section(
+                    "Verse",
+                    vec![Line::new(vec![text_part("Same"), text_part(" text")])],
+                ),
+                section(
+                    "Verse",
+                    vec![Line::new(vec![text_part("Same text"), text_part(" extra")])],
+                ),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Verse", "Verse [2]", "Verse [3]", "Verse [4]", "Verse [5]"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_treats_translation_changes_as_distinct() {
+        let song = Song {
+            sections: vec![
+                section(
+                    "Verse",
+                    vec![Line::new(vec![multilingual_part(&["Deutsch", "English"])])],
+                ),
+                section(
+                    "Verse",
+                    vec![Line::new(vec![multilingual_part(&["Deutsch", "Français"])])],
+                ),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.section_flow_names(), vec!["Verse", "Verse [2]"]);
+    }
+
+    #[test]
+    fn section_flow_names_treats_line_count_changes_as_distinct() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("One")]),
+                section("Verse", vec![text_line("One"), text_line("Two")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.section_flow_names(), vec!["Verse", "Verse [2]"]);
+    }
+
+    #[test]
+    fn section_flow_names_treats_different_line_order_as_distinct() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("One"), text_line("Two")]),
+                section("Verse", vec![text_line("Two"), text_line("One")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.section_flow_names(), vec!["Verse", "Verse [2]"]);
+    }
+
+    #[test]
+    fn section_flow_names_keeps_same_content_under_different_titles_separate() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Shared")]),
+                section("Chorus", vec![text_line("Shared")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(song.section_flow_names(), vec!["Verse", "Chorus"]);
+    }
+
+    #[test]
+    fn section_flow_names_skips_collisions_with_literal_suffixed_titles() {
+        let song = Song {
+            sections: vec![
+                section("Chorus", vec![text_line("Alpha")]),
+                section("Chorus [2]", vec![text_line("Literal two")]),
+                section("Chorus", vec![text_line("Beta")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Chorus", "Chorus [2]", "Chorus [3]"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_skips_multiple_occupied_suffixes() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Alpha")]),
+                section("Verse [2]", vec![text_line("Literal two")]),
+                section("Verse [3]", vec![text_line("Literal three")]),
+                section("Verse", vec![text_line("Beta")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["Verse", "Verse [2]", "Verse [3]", "Verse [4]"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_is_case_sensitive_and_handles_empty_titles() {
+        let song = Song {
+            sections: vec![
+                section("", vec![text_line("Blank title content")]),
+                section("", vec![text_line("Different blank title content")]),
+                section("chorus", vec![text_line("lowercase")]),
+                section("Chorus", vec![text_line("uppercase")]),
+            ],
+            ..Song::default()
+        };
+
+        assert_eq!(
+            song.section_flow_names(),
+            vec!["", " [2]", "chorus", "Chorus"]
+        );
+    }
+
+    #[test]
+    fn section_flow_names_does_not_mutate_song() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("Alpha")]),
+                section("Verse", vec![text_line("Beta")]),
+                section("Verse [2]", vec![text_line("Literal two")]),
+            ],
+            ..Song::default()
+        };
+        let original = song.clone();
+
+        let flow = song.section_flow_names();
+
+        assert_eq!(song, original);
+        assert_eq!(flow, vec!["Verse", "Verse [3]", "Verse [2]"]);
+    }
+
+    #[test]
+    fn sections_for_flow_reuses_first_body_and_emits_empty_references() {
+        let song = Song {
+            sections: vec![
+                section("Verse", vec![text_line("First line")]),
+                section("Chorus", vec![text_line("Second line")]),
+            ],
+            ..Song::default()
+        };
+        let flow = vec![
+            flow_item("Verse", 1),
+            flow_item("Verse", 2),
+            flow_item("Chorus", 1),
+        ];
+
+        let (sections, custom) = song.sections_for_flow(Some(&flow)).expect("flow");
+        assert!(custom);
+        assert_eq!(sections.len(), 3);
+        assert_eq!(sections[0].title, "Verse");
+        assert_eq!(sections[0].lines, vec![text_line("First line")]);
+        assert_eq!(sections[0].repeat_count, 1);
+        assert!(sections[1].lines.is_empty());
+        assert_eq!(sections[1].repeat_count, 2);
+        assert_eq!(sections[2].title, "Chorus");
+        assert_eq!(sections[2].lines, vec![text_line("Second line")]);
+    }
+
+    #[test]
+    fn sections_for_flow_rejects_unknown_titles_and_zero_repeats() {
+        let song = Song {
+            sections: vec![section("Verse", vec![text_line("One")])],
+            ..Song::default()
+        };
+
+        let unknown = song
+            .sections_for_flow(Some(&[flow_item("Missing", 1)]))
+            .expect_err("unknown title should fail");
+        assert!(matches!(unknown, Error::InvalidSongFlow(_)));
+
+        let invalid_repeats = song
+            .sections_for_flow(Some(&[flow_item("Verse", 0)]))
+            .expect_err("repeat zero should fail");
+        assert!(matches!(invalid_repeats, Error::InvalidSongFlow(_)));
     }
 }


### PR DESCRIPTION
Adds custom flow support to the visual rendering APIs while keeping ChordPro/WorshipPro output unchanged.

Highlights:
- exported `SongFlowItem { title, repeats }`
- `section_flow_names()` now returns flow items with repeat counts
- ANSI/plain, char page, and HTML renderers accept optional custom flows
- invalid custom flows return `Error::InvalidSongFlow`
- `None` or an empty flow preserves the current output exactly

Verification:
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `cargo check`
- `cargo doc --no-deps`
- `cargo doc --all-features --no-deps`