### PR TITLE
feat(songbeamer): add sng input and output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,15 @@ These rules are **mandatory** for any AI agent changing this repo.
 
 ### Required checks (definition of done)
 
-- **Tests pass**: Run `cargo test`.
-  - If anything fails, either fix and re-run, or list failing tests and why they weren’t fixed.
+- **Formatting**: Format edited Rust code with `cargo fmt --all`, then run
+  `cargo fmt --all -- --check`.
 
 - **Clippy clean**: Run `cargo clippy --all-features -- -D warnings`.
   - Code must build with **zero Clippy warnings**.
   - If some pre‑existing/externally caused warnings remain, minimize new ones and document what’s left and why.
 
-- **Formatting**: Run `cargo fmt` on edited code; don’t fight `rustfmt`.
+- **Tests pass**: Run `cargo test --verbose`.
+  - If anything fails, either fix and re-run, or list failing tests and why they weren’t fixed.
 
 - **Type check**: `cargo check` (or equivalent CI check) must succeed.
 
@@ -28,7 +29,14 @@ These rules are **mandatory** for any AI agent changing this repo.
 
 These extra tools are not required for every tiny change, but **never break existing CI/tooling** and prefer to run them when working in their area.
 
-GitHub Actions CI enforces these gates by running `cargo fmt --all -- --check`, `cargo clippy --all-features -- -D warnings`, and `cargo test` on every push and pull request targeting `main`.
+GitHub Actions CI runs the following Cargo commands, in this order, on every
+push and pull request targeting `main`. Agents must run all three exactly:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-features -- -D warnings
+cargo test --verbose
+```
 
 ### What every agent must report
 
@@ -63,4 +71,3 @@ All commits to this repo **must** use this format:
   - English only; no emoji in the subject.
   - One logical change per commit where practical.
   - Do **not** bypass hooks; if a hook fails, fix the issue and re-commit instead of forcing.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### ✨ Features
+
+- **SongBeamer input/output** — Read `.sng` files in SongBeamer's supported
+  encodings and write deterministic UTF-8/BOM `#Version=3` files with metadata,
+  multilingual lyrics, verse order, and native base64 chord positions.
+- **SongBeamer CLI conversion** — Accept `.sng` as both an input and output
+  extension, including case-insensitive extension matching.
+
 ---
 
 ## [0.14.0] — Apply song flow before render

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 askama = "0.16.0"
 lazy_static = "1.5.0"
+base64 = "0.22.1"
+encoding_rs = "0.8.35"
 
 [features]
 html = ["scraper"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chordlib
 
-Rust helpers to parse, transform, and render chord-and-lyrics songs. The crate understands common formats (ChordPro, Ultimate Guitar tabs) and can render to HTML, ChordPro, or a terminal-friendly view.
+Rust helpers to parse, transform, and render chord-and-lyrics songs. The crate understands common formats (ChordPro, SongBeamer, Ultimate Guitar tabs) and can render to HTML, ChordPro, SongBeamer, or a terminal-friendly view.
 
 ## Installation
 
@@ -45,7 +45,20 @@ cargo run --features=bin -- path/to/song.wp -o path/to/song.html
 
 Rendered HTML will be written to the path given after `-o`.
 
-The CLI supports transposition (`--key`), Nashville notation (`--nashville`), vowel-based chord shifting (`--vowel-move`), and output formats including ChordPro (`.cp`/`.wp`), HTML, and JSON.
+The CLI supports transposition (`--key`), Nashville notation (`--nashville`), vowel-based chord shifting (`--vowel-move`), and output formats including ChordPro (`.cp`/`.wp`), SongBeamer (`.sng`), HTML, and JSON.
+
+SongBeamer input and output preserve metadata, verse order, multilingual lyrics,
+and native `#Chords` data. Input follows SongBeamer's BOM rules (UTF-8,
+UTF-16LE, UTF-16BE, or Windows-1252 when there is no BOM). Output uses the
+portable SongBeamer recommendation of UTF-8 with a BOM and CRLF line endings:
+
+```bash
+cargo run --features=bin -- song.sng -o song.wp
+cargo run --features=bin -- song.wp -o song.sng
+```
+
+SongBeamer presentation-only settings and the distinct display semantics of
+`--`/`--A` page separators are not represented by chordlib's song model.
 
 ChordPro I/O supports **Nashville number notation** for chords: you can load files that use numbers (e.g. `[1][4][5]`, `[1m][4][5]`, `[b7/2]`) when the key is set with a letter name (e.g. `{key: C}`). Numerals are interpreted as scale degrees relative to that key; letter spellings (e.g. `[C]`, `[F]`) are also supported. The `{key: …}` directive must be a letter name, not a number. Use the `--nashville` flag when writing ChordPro to output chords in Nashville form; the key is always written as a letter (e.g. `{key: C}`).
 

--- a/docs/songbeamer-io-plan.md
+++ b/docs/songbeamer-io-plan.md
@@ -1,0 +1,265 @@
+# SongBeamer input/output implementation plan
+
+## Goal
+
+Add first-class SongBeamer `.sng` import and export to the `chordlib` library and
+CLI. Preserve the song information represented by the current `Song` model,
+including multilingual lyrics, section/verse order, chords, key, tempo, time
+signature, title, author, and copyright.
+
+The initial target is SongBeamer's text-based `#Version=3` format. The work
+should be driven by real, redistributable fixtures saved by SongBeamer rather
+than by assumptions about its undocumented fields.
+
+## Confirmed format facts
+
+- Header fields use `#Name=value`; the lyric body follows a `---` separator.
+- Slides are separated by `---` (with `--` and `--A` having related but
+  different presentation semantics).
+- `#VerseOrder` is a comma-separated sequence of verse markers and may refer to
+  the same marker multiple times without duplicating its body.
+- A slide's first line can be a standard marker such as `Vers 1`, `Chorus`, or
+  `Bridge`, or a custom `$$M=...` marker.
+- With multiple languages, lyrics are stored in repeating groups of lines;
+  `#LangCount` determines the group size. SongBeamer also has explicit line
+  prefixes such as `##1` and `##2`, which need fixture-based coverage.
+- `#Chords` is base64-encoded and contains chord positions tied to the lyric
+  body. Editing slide or marker lines can shift those positions.
+- SongBeamer detects ANSI/Windows-1252, UTF-8, UTF-16LE, and UTF-16BE by BOM;
+  without a BOM it assumes Windows-1252. New files should be UTF-8 with BOM.
+
+## Scope and compatibility policy
+
+### Version 1 support
+
+- Read `.sng` files using Windows-1252, UTF-8, UTF-16LE, or UTF-16BE according
+  to SongBeamer's BOM rules.
+- Write deterministic `#Version=3` files as UTF-8 with BOM and CRLF endings.
+- Map all fields that have an equivalent in `Song` and preserve safe,
+  unsupported scalar header fields in `Song::tags` under a `songbeamer.`
+  namespace.
+- Import and export normal slide separators, standard/custom verse markers,
+  `#VerseOrder`, multilingual lyric groups, and the `#Chords` payload.
+- Recognize `--` and `--A` on input, documenting that both collapse to a normal
+  `Section` boundary because the current model does not represent their display
+  differences.
+- Ignore visual-only properties (font, colors, backgrounds, transitions, and
+  editor identity) semantically. Preserve safe scalar values through tags when
+  practical, but do not add presentation fields to `Song` in this change.
+
+### Explicit non-goals for version 1
+
+- Pixel-perfect preservation of SongBeamer presentation settings.
+- Melody/audio/background asset import.
+- Byte-for-byte round trips of arbitrary `.sng` files.
+- Lossless representation of SongBeamer features for which `Song` has no model,
+  including the distinct display behavior of `--` and `--A`.
+- Guessing malformed chord offsets. Invalid base64, records, or out-of-range
+  positions should return a contextual parse error.
+
+## Data mapping
+
+| SongBeamer | `chordlib` | Notes |
+| --- | --- | --- |
+| `#Title`, `#TitleLangN` | `Song::titles` | Preserve language index and empty slots. |
+| `#Author` | `Song::artists` | Confirm delimiter behavior with fixtures; do not split names speculatively. |
+| `#(c)` / copyright fields | `Song::copyright` | Define precedence when several copyright-like fields occur. |
+| `#Key` | `Song::key` | Reuse `SimpleChord`; add fixtures for German `H`/`B`/`B=` spellings. |
+| `#Tempo` | `Song::tempo` | Reject invalid numbers with field context. |
+| `#Time` | `Song::time` | Accept the exact forms emitted by SongBeamer fixtures. |
+| `#LangCount` | `Part::languages` | Reconstruct each logical lyric line across all languages. |
+| slide marker | `Section::title` | Normalize recognized markers only enough for flow matching; preserve custom text. |
+| slide body | `Section::lines` | Convert lyric/chord positions into ordered `Part` values. |
+| `#VerseOrder` | section order/reference form | Parse unique bodies first, then use `Song::apply_flow`; repeated references should become empty-body sections as supported by the existing model. |
+| `#Chords` | `Part::chord` | Decode positions after the exact body/line-ending rules are established. |
+| other safe scalar headers | `Song::tags` | Store as `songbeamer.<name>` to avoid collisions. |
+
+For export, use `Song::flow_items()` and `Song::custom_flow()` to emit one body
+per distinct section variant plus a `#VerseOrder` that reproduces the expanded
+order and repeat counts. Define a deterministic marker for untitled sections
+and ensure duplicate titles with different bodies use unique marker names.
+
+## Implementation phases
+
+### 1. Build a compatibility fixture corpus
+
+Add small, original/public-domain files under `tests/fixtures/songbeamer/` for:
+
+- each supported encoding and BOM combination, including BOM-less CP1252;
+- LF and CRLF input;
+- minimal metadata and unknown header fields;
+- one, two, and three languages, including Unicode text;
+- standard, numbered, custom, missing, and repeated verse markers;
+- `#VerseOrder` with repeated markers and a section repeat count;
+- `---`, `--`, and `--A` separators;
+- chords at line start, mid-word, end-of-line, chord-only lines, adjacent chords,
+  slash chords, German notation, and non-ASCII lyric offsets;
+- malformed header values, malformed base64, invalid chord records, and chord
+  positions outside the lyric body.
+
+For every chord fixture, save the source `.sng` in SongBeamer and record the
+decoded `#Chords` payload in a neighboring test note. This makes the offset
+rules auditable.
+
+### 2. Add encoding and low-level document parsing
+
+Create `src/inputs/songbeamer/` with small, separately tested components:
+
+- `decode.rs`: BOM detection and decoding to Rust `String`; use Windows-1252
+  only when no BOM is present;
+- `document.rs`: split headers from body without changing body offsets, retain
+  line-ending and separator information long enough to decode chords;
+- `metadata.rs`: typed parsing and validation of supported headers;
+- `chords.rs`: base64 decoding and parsing of chord records into an intermediate
+  position table;
+- `mod.rs`: map the intermediate document into `Song`.
+
+Expose:
+
+```rust
+pub fn load(path: impl AsRef<std::path::Path>) -> Result<Song, Error>;
+pub fn load_bytes(input: &[u8]) -> Result<Song, Error>;
+pub fn load_string(input: &str) -> Result<Song, Error>;
+```
+
+`load_string` is the convenient already-decoded UTF-8 entry point;
+`load_bytes` is the canonical parser for actual `.sng` files. Include byte,
+line, field, or chord-record context in parse errors where possible.
+
+### 3. Map slides, languages, and flow into `Song`
+
+- Parse physical slides without prematurely discarding marker lines, because
+  chord positions may count them.
+- Detect standard marker lines and `$$M=` custom markers.
+- Reconstruct multilingual logical lines from `#LangCount` and explicit
+  language prefixes. Reject incomplete/ambiguous groups unless fixtures show a
+  well-defined SongBeamer fallback.
+- Convert each lyric line plus decoded chord positions to `Line`/`Part` while
+  preserving Unicode boundaries. Be explicit whether SongBeamer offsets count
+  bytes, UTF-16 code units, Unicode scalar values, or half-character units.
+- Parse distinct sections, resolve `#VerseOrder` to `SongFlowItem`s, and call
+  `Song::apply_flow`. Produce an error for unknown or ambiguous markers instead
+  of silently choosing a section.
+- Normalize absolute chords once, following the same invariant used by the
+  ChordPro input.
+
+### 4. Add deterministic SongBeamer output
+
+Create `src/outputs/songbeamer/` and export a `FormatSongBeamer` trait from
+`src/outputs/mod.rs`. The renderer should:
+
+- serialize a canonical header order and `#Version=3`;
+- write `#LangCount`, localized titles, mapped metadata, safe preserved fields,
+  unique section bodies, and `#VerseOrder`;
+- render each language group and verse marker into an intermediate body first;
+- calculate chord positions from that exact body representation, then encode
+  the `#Chords` header;
+- format chords through the existing chord representation APIs, including
+  transposition and German spelling rules confirmed by fixtures;
+- return bytes with UTF-8 BOM and CRLF line endings.
+
+Suggested public API:
+
+```rust
+pub trait FormatSongBeamer {
+    fn format_songbeamer(
+        &self,
+        key: Option<&SimpleChord>,
+        representation: Option<&ChordRepresentation>,
+    ) -> Result<Vec<u8>, Error>;
+}
+```
+
+Do not offer a single-language filter initially: changing the language count
+also changes the chord/body offsets and would silently discard data. It can be
+added later as an explicit export option.
+
+### 5. Wire the CLI and public documentation
+
+- Add `pub mod songbeamer;` to `src/inputs/mod.rs` and export
+  `FormatSongBeamer` from `src/outputs/mod.rs`.
+- In `src/main.rs`, recognize `.sng` input case-insensitively and load it as
+  bytes. Recognize `.sng` output and write the renderer's bytes.
+- Replace the growing extension `if` chain with a small parsed input/output
+  format enum so detection and error messages can be unit tested.
+- Update CLI help, crate-level docs, and `README.md` with the supported subset,
+  encoding behavior, a library example, and a CLI conversion example.
+- Update `CHANGELOG.md` when the feature is released.
+
+### 6. Test interoperability and round trips
+
+Add tests at three levels:
+
+1. Unit tests for encoding, metadata, separator, verse marker, verse order, and
+   chord-record codecs.
+2. Fixture tests asserting `.sng -> Song` and `Song -> .sng -> Song`, comparing
+   semantic `Song` values rather than header ordering or original bytes.
+3. CLI integration tests for `.sng` input/output, unknown formats, mixed-case
+   extensions, transposition, and invalid files.
+
+Finally, open generated fixtures in a supported SongBeamer release and verify:
+
+- titles, authors, key, tempo, and time signature;
+- slide grouping and verse order;
+- all language lines;
+- chord spelling and visual placement, especially around Unicode characters;
+- a save/reopen cycle in SongBeamer followed by re-import into `chordlib`.
+
+Record the tested SongBeamer version and any known deviations in the README.
+
+## Dependencies
+
+Likely additions are:
+
+- `base64` for `#Chords`;
+- `encoding_rs` for deterministic Windows-1252 decoding (UTF-16 can be handled
+  directly or consistently through the same layer).
+
+Before adding them, confirm the standard library cannot meet the required
+behavior clearly and safely. If dependencies change, run `cargo audit` and
+`cargo deny` when available, in addition to the normal repository gates.
+
+## Definition of done
+
+- Public byte-oriented input and output APIs are documented and exported.
+- `.sng` works as both CLI input and output without changing existing formats.
+- Supported metadata, lyrics, languages, flow, and chords survive semantic
+  round trips.
+- Malformed input returns `Error` and never panics.
+- Unsupported/lossy fields and separator behavior are documented.
+- Generated UTF-8 BOM/CRLF files pass manual interoperability testing in
+  SongBeamer.
+- `cargo fmt --all -- --check` passes.
+- `cargo check --all-features` passes.
+- `cargo test` passes.
+- `cargo clippy --all-features -- -D warnings` passes with zero warnings.
+- `cargo doc --no-deps --all-features` passes.
+- If dependencies changed, `cargo audit` and configured `cargo deny` checks are
+  run and their results documented.
+
+## Risks and decisions to settle during the fixture phase
+
+1. Exact `#Chords` record grammar and whether offsets count bytes, characters,
+   UTF-16 units, or half-character positions.
+2. Whether marker and separator lines contribute to chord offsets in every
+   supported SongBeamer version.
+3. Exact mapping of chord spelling (`H`, `B`, `B=`) to `SimpleChord` and back.
+4. `#VerseOrder` escaping when custom marker names contain commas.
+5. How SongBeamer represents incomplete multilingual groups and explicit
+   `##N` continuation lines.
+6. Which unknown header fields are safe scalar values versus encoded/binary or
+   path-dependent data that must be dropped.
+7. Whether `Song::tags` preservation is sufficient or a dedicated extension
+   map is needed for lossless metadata round trips.
+
+Do not finalize the chord codec or claim lossless compatibility until these
+questions are answered by fixtures generated in SongBeamer.
+
+## References
+
+- [SongBeamer wiki: Song editor, slide separators, languages, and verse markers](https://wiki.songbeamer.de/index.php?title=Song)
+- [SongBeamer forum: encoding and BOM behavior](https://forum-en.songbeamer.de/viewtopic.php?t=166)
+- [SongBeamer forum: `#VerseOrder` example and chord storage discussion](https://forum.songbeamer.de/viewtopic.php?t=4657)
+- [SongBeamer forum: recommendation to create UTF-8 files with a BOM](https://forum.songbeamer.de/viewtopic.php?t=4574)
+- [OpenLP SongBeamer chord-position interoperability report](https://discuss.openlp.org/d/4008-songbeamer-import-chords-start-with-second-line)
+- [Independent SongBeamer parser behavior summary](https://www.skypack.dev/view/songbeamer)

--- a/src/inputs/chord_pro/iter_section.rs
+++ b/src/inputs/chord_pro/iter_section.rs
@@ -148,12 +148,11 @@ impl<'a> Iterator for SectionIterator<'a> {
                 } else {
                     self.lines_cache.push(line.trim_end());
                 }
-            } else if let Some(title) = self.section_title_cache {
+            } else {
+                let title = self.section_title_cache?;
                 let lines_cache = std::mem::take(&mut self.lines_cache);
                 self.section_title_cache = None;
                 return Some((title, lines_cache));
-            } else {
-                return None;
             }
         }
     }

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -1,2 +1,3 @@
 pub mod chord_pro;
+pub mod songbeamer;
 pub mod ultimate_guitar;

--- a/src/inputs/songbeamer.rs
+++ b/src/inputs/songbeamer.rs
@@ -1,0 +1,709 @@
+//! SongBeamer `.sng` input support.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use base64::Engine as _;
+use encoding_rs::WINDOWS_1252;
+
+use crate::Error;
+use crate::types::{Chord, Line, Part, Section, SimpleChord, Song, SongFlowItem};
+
+#[derive(Clone, Copy)]
+enum TextEncoding {
+    Utf8,
+    Utf16Le,
+    Utf16Be,
+    Windows1252,
+}
+
+#[derive(Debug)]
+struct ChordPosition {
+    column: f64,
+    line: i32,
+    chord: String,
+}
+
+#[derive(Debug)]
+struct PhysicalLine {
+    number: i32,
+    text: String,
+}
+
+#[derive(Debug, Default)]
+struct PhysicalSlide {
+    lines: Vec<PhysicalLine>,
+}
+
+/// Load a SongBeamer file from disk.
+pub fn load(path: impl AsRef<Path>) -> Result<Song, Error> {
+    load_bytes(&std::fs::read(path)?)
+}
+
+/// Load a SongBeamer file from bytes, applying SongBeamer's BOM rules.
+pub fn load_bytes(input: &[u8]) -> Result<Song, Error> {
+    let (text, encoding) = decode_document(input)?;
+    parse_document(&text, encoding)
+}
+
+/// Load an already decoded UTF-8 SongBeamer document.
+pub fn load_string(input: &str) -> Result<Song, Error> {
+    parse_document(
+        input.strip_prefix('\u{feff}').unwrap_or(input),
+        TextEncoding::Utf8,
+    )
+}
+
+fn decode_document(input: &[u8]) -> Result<(String, TextEncoding), Error> {
+    if let Some(bytes) = input.strip_prefix(&[0xef, 0xbb, 0xbf]) {
+        let text = std::str::from_utf8(bytes)
+            .map_err(|error| Error::Parse(format!("invalid UTF-8 SongBeamer file: {error}")))?;
+        return Ok((text.to_string(), TextEncoding::Utf8));
+    }
+    if let Some(bytes) = input.strip_prefix(&[0xff, 0xfe]) {
+        return Ok((decode_utf16(bytes, true)?, TextEncoding::Utf16Le));
+    }
+    if let Some(bytes) = input.strip_prefix(&[0xfe, 0xff]) {
+        return Ok((decode_utf16(bytes, false)?, TextEncoding::Utf16Be));
+    }
+
+    let (text, _, _) = WINDOWS_1252.decode(input);
+    Ok((text.into_owned(), TextEncoding::Windows1252))
+}
+
+fn decode_utf16(input: &[u8], little_endian: bool) -> Result<String, Error> {
+    if !input.len().is_multiple_of(2) {
+        return Err(Error::Parse(
+            "UTF-16 SongBeamer file has an odd byte length".into(),
+        ));
+    }
+    let units = input.chunks_exact(2).map(|bytes| {
+        if little_endian {
+            u16::from_le_bytes([bytes[0], bytes[1]])
+        } else {
+            u16::from_be_bytes([bytes[0], bytes[1]])
+        }
+    });
+    String::from_utf16(&units.collect::<Vec<_>>())
+        .map_err(|error| Error::Parse(format!("invalid UTF-16 SongBeamer file: {error}")))
+}
+
+fn decode_chord_payload(input: &[u8], encoding: TextEncoding) -> Result<String, Error> {
+    match encoding {
+        TextEncoding::Utf8 => std::str::from_utf8(input)
+            .map(str::to_owned)
+            .map_err(|error| Error::Parse(format!("invalid UTF-8 in #Chords: {error}"))),
+        TextEncoding::Utf16Le => decode_utf16(input, true),
+        TextEncoding::Utf16Be => decode_utf16(input, false),
+        TextEncoding::Windows1252 => Ok(WINDOWS_1252.decode(input).0.into_owned()),
+    }
+}
+
+fn parse_document(input: &str, encoding: TextEncoding) -> Result<Song, Error> {
+    let lines = input
+        .split_terminator('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .collect::<Vec<_>>();
+    let body_start = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with("---"))
+        .ok_or_else(|| Error::Parse("SongBeamer file has no initial --- separator".into()))?;
+
+    let mut headers = BTreeMap::new();
+    for (index, line) in lines[..body_start].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some(header) = line.strip_prefix('#') else {
+            return Err(Error::Parse(format!(
+                "invalid SongBeamer header on line {}",
+                index + 1
+            )));
+        };
+        let Some((name, value)) = header.split_once('=') else {
+            return Err(Error::Parse(format!(
+                "SongBeamer header #{header} has no value"
+            )));
+        };
+        headers.insert(name.to_string(), value.to_string());
+    }
+
+    let title = headers
+        .get("Title")
+        .filter(|title| !title.trim().is_empty())
+        .ok_or_else(|| Error::Parse("SongBeamer file has no title".into()))?
+        .trim()
+        .to_string();
+    let lang_count = parse_number::<usize>(&headers, "LangCount")?.unwrap_or(1);
+    if lang_count == 0 {
+        return Err(Error::Parse("#LangCount must be at least 1".into()));
+    }
+
+    let key = headers
+        .get("Key")
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| parse_songbeamer_key(value))
+        .transpose()?;
+    let chord_positions = headers
+        .get("Chords")
+        .map(|value| parse_chords(value, encoding))
+        .transpose()?
+        .unwrap_or_default();
+
+    let physical_slides = parse_slides(&lines[body_start..]);
+    let primary_lines = primary_line_numbers(&physical_slides, lang_count)?;
+    for position in &chord_positions {
+        if position.line != -1 && !primary_lines.contains(&position.line) {
+            return Err(Error::Parse(format!(
+                "#Chords record targets marker, separator, translation, or missing physical line {}",
+                position.line
+            )));
+        }
+    }
+    let mut sections = physical_slides
+        .into_iter()
+        .enumerate()
+        .map(|(index, slide)| {
+            map_slide(slide, index + 1, lang_count, &chord_positions, key.as_ref())
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let leading_chords = chord_positions
+        .iter()
+        .filter(|position| position.line == -1)
+        .collect::<Vec<_>>();
+    if !leading_chords.is_empty() {
+        let empty_languages = vec![""; lang_count];
+        let line = build_line(&empty_languages, leading_chords, lang_count, key.as_ref())?;
+        let first = sections
+            .first_mut()
+            .ok_or_else(|| Error::Parse("#Chords uses line -1 but the song has no slide".into()))?;
+        first.lines.insert(0, line);
+    }
+
+    let mut titles = vec![title];
+    let mut localized_titles = headers
+        .iter()
+        .filter_map(|(name, value)| {
+            name.strip_prefix("TitleLang")
+                .and_then(|index| index.parse::<usize>().ok())
+                .map(|index| (index, value.clone()))
+        })
+        .collect::<Vec<_>>();
+    localized_titles.sort_by_key(|(index, _)| *index);
+    for (index, value) in localized_titles {
+        if index < 2 {
+            continue;
+        }
+        titles.resize(index, String::new());
+        titles[index - 1] = value;
+    }
+
+    let tempo = parse_number::<u32>(&headers, "Tempo")?.or(parse_number::<u32>(&headers, "Speed")?);
+    let time = headers
+        .get("Time")
+        .map(|value| parse_time(value))
+        .transpose()?;
+    let mut tags = BTreeMap::new();
+    for (name, value) in &headers {
+        if !is_mapped_header(name) && !value.contains(['\r', '\n']) {
+            tags.insert(format!("songbeamer.{name}"), value.clone());
+        }
+    }
+
+    let mut song = Song {
+        titles,
+        subtitle: headers.get("OTitle").cloned(),
+        copyright: headers.get("(c)").cloned(),
+        key,
+        artists: headers
+            .get("Author")
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .into_iter()
+            .collect(),
+        languages: vec![String::new(); lang_count],
+        tempo,
+        time,
+        tags,
+        sections,
+    };
+
+    if let Some(order) = headers.get("VerseOrder") {
+        let flow = parse_verse_order(order, &song.sections)?;
+        song.apply_flow(flow)?;
+    }
+    Ok(song)
+}
+
+fn parse_number<T>(headers: &BTreeMap<String, String>, name: &str) -> Result<Option<T>, Error>
+where
+    T: std::str::FromStr,
+{
+    headers
+        .get(name)
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| {
+            value
+                .trim()
+                .parse::<T>()
+                .map_err(|_| Error::Parse(format!("invalid #{name} value {value:?}")))
+        })
+        .transpose()
+}
+
+fn parse_time(value: &str) -> Result<(u32, u32), Error> {
+    let (numerator, denominator) = value
+        .trim()
+        .split_once('/')
+        .ok_or_else(|| Error::Parse(format!("invalid #Time value {value:?}")))?;
+    let numerator = numerator
+        .trim()
+        .parse()
+        .map_err(|_| Error::Parse(format!("invalid #Time value {value:?}")))?;
+    let denominator = denominator
+        .trim()
+        .parse()
+        .map_err(|_| Error::Parse(format!("invalid #Time value {value:?}")))?;
+    if denominator == 0 {
+        return Err(Error::Parse("#Time denominator must not be zero".into()));
+    }
+    Ok((numerator, denominator))
+}
+
+fn parse_songbeamer_key(value: &str) -> Result<SimpleChord, Error> {
+    let value = normalize_chord_name(value.trim());
+    SimpleChord::try_from(value.as_str())
+        .map_err(|_| Error::Parse(format!("invalid #Key value {value:?}")))
+}
+
+fn normalize_chord_name(value: &str) -> String {
+    value.replace('<', "b").replace("B=", "B")
+}
+
+fn parse_chords(value: &str, encoding: TextEncoding) -> Result<Vec<ChordPosition>, Error> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value.trim())
+        .map_err(|error| Error::Parse(format!("invalid base64 in #Chords: {error}")))?;
+    let decoded = decode_chord_payload(&bytes, encoding)?;
+    decoded
+        .split('\r')
+        .filter(|record| !record.is_empty())
+        .enumerate()
+        .map(|(index, record)| {
+            let mut fields = record.splitn(3, ',');
+            let column = fields.next().and_then(|field| field.parse::<f64>().ok());
+            let line = fields.next().and_then(|field| field.parse::<i32>().ok());
+            let chord = fields.next();
+            let (Some(column), Some(line), Some(chord)) = (column, line, chord) else {
+                return Err(Error::Parse(format!(
+                    "invalid #Chords record {}: {record:?}",
+                    index + 1
+                )));
+            };
+            if !column.is_finite() {
+                return Err(Error::Parse(format!(
+                    "non-finite column in #Chords record {}",
+                    index + 1
+                )));
+            }
+            Ok(ChordPosition {
+                column,
+                line,
+                chord: normalize_chord_name(chord),
+            })
+        })
+        .collect()
+}
+
+fn parse_slides(lines: &[&str]) -> Vec<PhysicalSlide> {
+    let mut slides = Vec::new();
+    let mut current = None::<PhysicalSlide>;
+    let mut line_number = -1;
+
+    for line in lines {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("---") || trimmed.starts_with("--") {
+            if let Some(slide) = current.take()
+                && !slide.lines.is_empty()
+            {
+                slides.push(slide);
+            }
+            current = Some(PhysicalSlide::default());
+            line_number += 1;
+        } else if let Some(slide) = current.as_mut() {
+            slide.lines.push(PhysicalLine {
+                number: line_number,
+                text: (*line).to_string(),
+            });
+            line_number += 1;
+        }
+    }
+    if let Some(slide) = current
+        && !slide.lines.is_empty()
+    {
+        slides.push(slide);
+    }
+    slides
+}
+
+fn primary_line_numbers(
+    slides: &[PhysicalSlide],
+    lang_count: usize,
+) -> Result<BTreeSet<i32>, Error> {
+    let mut result = BTreeSet::new();
+    for (index, slide) in slides.iter().enumerate() {
+        let marker_count = usize::from(
+            slide
+                .lines
+                .first()
+                .is_some_and(|line| verse_marker(&line.text).is_some()),
+        );
+        let lyrics = &slide.lines[marker_count..];
+        if !lyrics.len().is_multiple_of(lang_count) {
+            return Err(Error::Parse(format!(
+                "slide {} has {} lyric lines, not a multiple of #LangCount={lang_count}",
+                index + 1,
+                lyrics.len()
+            )));
+        }
+        result.extend(lyrics.chunks(lang_count).map(|group| group[0].number));
+    }
+    Ok(result)
+}
+
+fn map_slide(
+    mut slide: PhysicalSlide,
+    slide_number: usize,
+    lang_count: usize,
+    chords: &[ChordPosition],
+    key: Option<&SimpleChord>,
+) -> Result<Section, Error> {
+    let marker = slide
+        .lines
+        .first()
+        .and_then(|line| verse_marker(&line.text));
+    if marker.is_some() {
+        slide.lines.remove(0);
+    }
+    let title = match marker.as_deref().and_then(parse_generated_variant_marker) {
+        Some((title, _)) => Some(title.to_string()),
+        None => marker,
+    };
+    if !slide.lines.len().is_multiple_of(lang_count) {
+        return Err(Error::Parse(format!(
+            "slide {slide_number} has {} lyric lines, not a multiple of #LangCount={lang_count}",
+            slide.lines.len()
+        )));
+    }
+
+    let mut lines = Vec::new();
+    for group in slide.lines.chunks(lang_count) {
+        let primary = &group[0];
+        for translated in &group[1..] {
+            if chords.iter().any(|chord| chord.line == translated.number) {
+                return Err(Error::Parse(format!(
+                    "chords on translated physical line {} are not representable",
+                    translated.number
+                )));
+            }
+        }
+        let translations = group
+            .iter()
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>();
+        let line_chords = chords
+            .iter()
+            .filter(|chord| chord.line == primary.number)
+            .collect::<Vec<_>>();
+        lines.push(build_line(&translations, line_chords, lang_count, key)?);
+    }
+
+    Ok(Section::new(title.unwrap_or_default(), lines))
+}
+
+fn build_line(
+    translations: &[&str],
+    mut chords: Vec<&ChordPosition>,
+    lang_count: usize,
+    key: Option<&SimpleChord>,
+) -> Result<Line, Error> {
+    chords.sort_by(|left, right| left.column.total_cmp(&right.column));
+    let primary = translations.first().copied().unwrap_or_default();
+    let char_count = primary.chars().count();
+    let mut parts = Vec::<Part>::new();
+    let mut cursor = 0usize;
+
+    for position in chords {
+        let column = position.column.ceil().max(0.0) as usize;
+        if column > char_count {
+            return Err(Error::Parse(format!(
+                "chord {:?} column {} exceeds lyric length {char_count} on physical line {}",
+                position.chord, position.column, position.line
+            )));
+        }
+        if column > cursor {
+            append_primary_text(&mut parts, char_slice(primary, cursor, column));
+        }
+        let chord = Chord::from_str_with_key(&position.chord, key).map_err(|error| {
+            Error::Parse(format!(
+                "invalid chord {:?} on physical line {}: {error}",
+                position.chord, position.line
+            ))
+        })?;
+        parts.push(Part {
+            chord: Some(chord),
+            languages: vec![String::new(); lang_count],
+            comment: false,
+        });
+        cursor = column;
+    }
+    if cursor < char_count || parts.is_empty() {
+        append_primary_text(&mut parts, char_slice(primary, cursor, char_count));
+    }
+    for part in &mut parts {
+        part.languages.resize(lang_count, String::new());
+    }
+    for (language, text) in translations.iter().enumerate().skip(1) {
+        parts[0].languages[language] = (*text).to_string();
+    }
+    Ok(Line::new(parts))
+}
+
+fn append_primary_text(parts: &mut Vec<Part>, text: &str) {
+    if let Some(part) = parts.last_mut() {
+        part.languages[0].push_str(text);
+    } else {
+        parts.push(Part {
+            chord: None,
+            languages: vec![text.to_string()],
+            comment: false,
+        });
+    }
+}
+
+fn char_slice(input: &str, start: usize, end: usize) -> &str {
+    let start = input
+        .char_indices()
+        .nth(start)
+        .map_or(input.len(), |(index, _)| index);
+    let end = input
+        .char_indices()
+        .nth(end)
+        .map_or(input.len(), |(index, _)| index);
+    &input[start..end]
+}
+
+fn verse_marker(line: &str) -> Option<String> {
+    let line = line.trim();
+    if line
+        .get(..4)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("$$m="))
+    {
+        return Some(line[4..].trim().to_string());
+    }
+    let words = line.split_whitespace().collect::<Vec<_>>();
+    if !(1..=2).contains(&words.len()) || !is_marker_name(words[0]) {
+        return None;
+    }
+    if words.len() == 2
+        && !words[1]
+            .chars()
+            .all(|character| character.is_alphanumeric())
+    {
+        return None;
+    }
+    Some(line.to_string())
+}
+
+fn is_marker_name(value: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "intro",
+        "vers",
+        "verse",
+        "strophe",
+        "pre-bridge",
+        "bridge",
+        "misc",
+        "pre-refrain",
+        "refrain",
+        "pre-chorus",
+        "chorus",
+        "pre-coda",
+        "zwischenspiel",
+        "instrumental",
+        "interlude",
+        "coda",
+        "ending",
+        "ende",
+        "outro",
+        "teil",
+        "part",
+        "chor",
+        "solo",
+        "breakdown",
+        "vamp",
+        "turnaround",
+        "tag",
+        "andere",
+        "unknown",
+        "unbekannt",
+        "unbenannt",
+        "hidden",
+        "invisible",
+        "comment",
+    ];
+    MARKERS
+        .iter()
+        .any(|marker| value.eq_ignore_ascii_case(marker))
+}
+
+fn parse_verse_order(order: &str, sections: &[Section]) -> Result<Vec<SongFlowItem>, Error> {
+    order
+        .split(',')
+        .map(str::trim)
+        .filter(|marker| !marker.is_empty())
+        .map(|marker| {
+            let (title, requested_occurrence) = parse_generated_variant_marker(marker)
+                .map_or((marker, None), |(title, occurrence)| {
+                    (title, Some(occurrence))
+                });
+            let matches = sections
+                .iter()
+                .enumerate()
+                .filter(|(_, section)| section.title.eq_ignore_ascii_case(title))
+                .collect::<Vec<_>>();
+            if matches.is_empty() {
+                return Err(Error::Parse(format!(
+                    "#VerseOrder references unknown marker {marker:?}"
+                )));
+            }
+            let mut distinct_bodies = Vec::new();
+            for (_, section) in &matches {
+                if !distinct_bodies.contains(&&section.lines) {
+                    distinct_bodies.push(&section.lines);
+                }
+            }
+            let occurrence_index = if let Some(occurrence) = requested_occurrence {
+                if occurrence >= distinct_bodies.len() {
+                    return Err(Error::Parse(format!(
+                        "#VerseOrder references missing generated variant {marker:?}"
+                    )));
+                }
+                occurrence as u32
+            } else if distinct_bodies.len() > 1 {
+                return Err(Error::Parse(format!(
+                    "#VerseOrder marker {marker:?} is ambiguous"
+                )));
+            } else {
+                0
+            };
+            Ok(SongFlowItem {
+                title: matches[0].1.title.clone(),
+                occurrence_index,
+                repeats: 1,
+            })
+        })
+        .collect()
+}
+
+fn parse_generated_variant_marker(marker: &str) -> Option<(&str, usize)> {
+    let (title, suffix) = marker.rsplit_once(" [chordlib:")?;
+    let occurrence = suffix.strip_suffix(']')?.parse::<usize>().ok()?;
+    occurrence.checked_sub(1).map(|index| (title, index))
+}
+
+fn is_mapped_header(name: &str) -> bool {
+    matches!(
+        name,
+        "Title"
+            | "Author"
+            | "(c)"
+            | "Key"
+            | "Tempo"
+            | "Speed"
+            | "Time"
+            | "LangCount"
+            | "Chords"
+            | "VerseOrder"
+            | "Version"
+            | "Editor"
+            | "OTitle"
+    ) || name.starts_with("TitleLang")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_minimal_song_with_chords_and_verse_order() {
+        let chord_data = base64::engine::general_purpose::STANDARD.encode("0,1,C\r5,1,G\r");
+        let input = format!(
+            "#LangCount=1\r\n#VerseOrder=Verse 1,Chorus,Verse 1\r\n#Title=Example\r\n#Key=C\r\n#Chords={chord_data}\r\n#Version=3\r\n---\r\nVerse 1\r\nHello world\r\n---\r\nChorus\r\nSing\r\n"
+        );
+        let song = load_string(&input).expect("parse SongBeamer");
+        assert_eq!(song.title(), "Example");
+        assert_eq!(song.sections.len(), 3);
+        assert_eq!(song.sections[0].title, "Verse 1");
+        assert_eq!(song.sections[0].lines[0].parts.len(), 2);
+        assert!(song.sections[2].lines.is_empty());
+    }
+
+    #[test]
+    fn loads_bomless_windows_1252() {
+        let bytes =
+            b"#LangCount=1\r\n#Title=Gr\xfc\xdfe\r\n#Version=3\r\n---\r\nVers 1\r\nSch\xf6n\r\n";
+        let song = load_bytes(bytes).expect("parse CP1252");
+        assert_eq!(song.title(), "Grüße");
+        assert_eq!(song.sections[0].lines[0].parts[0].languages[0], "Schön");
+    }
+
+    #[test]
+    fn rejects_chord_beyond_line() {
+        let chord_data = base64::engine::general_purpose::STANDARD.encode("99,1,C\r");
+        let input = format!(
+            "#LangCount=1\n#Title=Example\n#Key=C\n#Chords={chord_data}\n---\nVerse 1\nShort"
+        );
+        let error = load_string(&input).expect_err("invalid column");
+        assert!(error.to_string().contains("exceeds lyric length"));
+    }
+
+    #[test]
+    fn loads_utf16le_and_multilingual_lyrics() {
+        let input = "#LangCount=2\r\n#Title=Grüße\r\n#Version=3\r\n---\r\nVerse 1\r\nHello\r\nHallo\r\nWorld\r\nWelt\r\n";
+        let mut bytes = vec![0xff, 0xfe];
+        bytes.extend(input.encode_utf16().flat_map(u16::to_le_bytes));
+        let song = load_bytes(&bytes).expect("parse UTF-16LE");
+        assert_eq!(song.title(), "Grüße");
+        assert_eq!(song.sections[0].lines.len(), 2);
+        assert_eq!(
+            song.sections[0].lines[0].parts[0].languages,
+            ["Hello", "Hallo"]
+        );
+        assert_eq!(
+            song.sections[0].lines[1].parts[0].languages,
+            ["World", "Welt"]
+        );
+    }
+
+    #[test]
+    fn imports_songbeamer_chord_only_line_minus_one() {
+        let chord_data = base64::engine::general_purpose::STANDARD.encode("-1,-1,C\r0,-1,G\r");
+        let input = format!(
+            "#LangCount=1\n#Title=Intro\n#Key=C\n#Chords={chord_data}\n---\nVerse 1\nLyrics"
+        );
+        let song = load_string(&input).expect("parse chord-only line");
+        let leading = &song.sections[0].lines[0];
+        assert_eq!(leading.parts.len(), 2);
+        assert!(leading.parts.iter().all(|part| part.chord.is_some()));
+    }
+
+    #[test]
+    fn rejects_chords_attached_to_a_marker_line() {
+        let chord_data = base64::engine::general_purpose::STANDARD.encode("0,0,C\r");
+        let input =
+            format!("#LangCount=1\n#Title=Bad\n#Key=C\n#Chords={chord_data}\n---\nVerse 1\nLyrics");
+        let error = load_string(&input).expect_err("marker chord is unsupported");
+        assert!(error.to_string().contains("targets marker"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Library helpers to parse, transform, and render chord-and-lyrics songs.
 //!
 //! The crate focuses on common song markup formats such as ChordPro and
-//! Ultimate Guitar tabs, while providing renderers for HTML and ChordPro
+//! Ultimate Guitar tabs and SongBeamer songs, while providing renderers for HTML, ChordPro,
 //! outputs. Feature flags:
 //! - `html`: parse and render HTML content.
 //! - `bin`: build the `chordlib` CLI (depends on `clap`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 use chordlib::Error;
-use chordlib::outputs::{FormatChordPro, FormatHTML, FormatRender};
+use chordlib::outputs::{FormatChordPro, FormatHTML, FormatRender, FormatSongBeamer};
 use chordlib::types::{ChordRepresentation, SimpleChord};
 
 #[derive(Debug, Parser)]
@@ -37,12 +37,15 @@ fn main() -> Result<(), Error> {
         ChordRepresentation::Default
     });
 
-    let mut song = if args.input.ends_with(".cp")
-        || args.input.ends_with(".wp")
-        || args.input.ends_with(".chopro")
+    let input_lower = args.input.to_ascii_lowercase();
+    let mut song = if input_lower.ends_with(".cp")
+        || input_lower.ends_with(".wp")
+        || input_lower.ends_with(".chopro")
     {
         chordlib::inputs::chord_pro::load(&args.input)
-    } else if args.input.ends_with(".html") {
+    } else if input_lower.ends_with(".sng") {
+        chordlib::inputs::songbeamer::load(&args.input)
+    } else if input_lower.ends_with(".html") {
         let html = std::fs::read_to_string(&args.input)?;
         chordlib::inputs::ultimate_guitar::load_html(&html)
     } else {
@@ -71,22 +74,28 @@ fn main() -> Result<(), Error> {
         );
     }
 
-    if args.output.ends_with(".cp") || args.output.ends_with(".chopro") {
+    let output_lower = args.output.to_ascii_lowercase();
+    if output_lower.ends_with(".cp") || output_lower.ends_with(".chopro") {
         Ok(std::fs::write(
             args.output,
             (&song).format_chord_pro(None, representation.as_ref(), args.language, false),
         )?)
-    } else if args.output.ends_with(".wp") {
+    } else if output_lower.ends_with(".wp") {
         Ok(std::fs::write(
             args.output,
             (&song).format_chord_pro(None, representation.as_ref(), args.language, true),
         )?)
-    } else if args.output.ends_with(".json") {
+    } else if output_lower.ends_with(".json") {
         Ok(std::fs::write(args.output, serde_json::to_string(&song)?)?)
-    } else if args.output.ends_with(".html") {
+    } else if output_lower.ends_with(".html") {
         Ok(std::fs::write(
             args.output,
             (&song).format_html(None, representation.as_ref(), args.language, None)?,
+        )?)
+    } else if output_lower.ends_with(".sng") {
+        Ok(std::fs::write(
+            args.output,
+            (&song).format_songbeamer(None, representation.as_ref())?,
         )?)
     } else if args.output.is_empty() {
         Ok(())

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -3,6 +3,7 @@ mod chord_pro;
 mod html;
 mod outputline;
 mod render;
+mod songbeamer;
 
 pub use charpage::{CharPage, CharPageSet, FormatCharPages};
 pub use chord_pro::FormatChordPro;
@@ -10,3 +11,4 @@ pub use html::{FormatHTML, render_section, wrap_html};
 pub(crate) use outputline::repeat_label;
 pub use outputline::{FormatOutputLines, OutputLine};
 pub use render::FormatRender;
+pub use songbeamer::FormatSongBeamer;

--- a/src/outputs/songbeamer.rs
+++ b/src/outputs/songbeamer.rs
@@ -1,0 +1,394 @@
+//! Deterministic SongBeamer `.sng` output.
+
+use std::collections::BTreeMap;
+
+use base64::Engine as _;
+
+use crate::Error;
+use crate::types::{ChordRepresentation, Line, Section, SimpleChord, Song};
+
+/// Format a song as a SongBeamer `#Version=3` document.
+pub trait FormatSongBeamer {
+    /// Return a UTF-8 document with a BOM and CRLF line endings.
+    fn format_songbeamer(
+        &self,
+        key: Option<&SimpleChord>,
+        representation: Option<&ChordRepresentation>,
+    ) -> Result<Vec<u8>, Error>;
+}
+
+struct Body<'a> {
+    title: String,
+    marker: String,
+    section: &'a Section,
+}
+
+impl FormatSongBeamer for &Song {
+    fn format_songbeamer(
+        &self,
+        key: Option<&SimpleChord>,
+        representation: Option<&ChordRepresentation>,
+    ) -> Result<Vec<u8>, Error> {
+        if self.title().is_empty() {
+            return Err(Error::Other(
+                "SongBeamer output requires a non-empty song title".into(),
+            ));
+        }
+        let representation = representation.unwrap_or(&ChordRepresentation::Default);
+        let render_key = key.or(self.key.as_ref()).cloned().unwrap_or_default();
+        let (mut bodies, flow) = collect_bodies_and_flow(self)?;
+        assign_markers(&mut bodies);
+        let verse_order = flow
+            .iter()
+            .map(|body_index| bodies[*body_index].marker.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        let lang_count = song_language_count(self);
+
+        let mut body_lines = Vec::new();
+        let mut chord_records = Vec::new();
+        let mut physical_line = -1i32;
+        for body in &bodies {
+            body_lines.push("---".to_string());
+            physical_line += 1;
+            body_lines.push(marker_line(&body.marker));
+            physical_line += 1;
+            for line in &body.section.lines {
+                for language in 0..lang_count {
+                    let (lyrics, chords) =
+                        render_line(line, language, &render_key, representation, physical_line);
+                    body_lines.push(lyrics);
+                    if language == 0 {
+                        chord_records.extend(chords);
+                    }
+                    physical_line += 1;
+                }
+            }
+        }
+        if body_lines.is_empty() {
+            body_lines.push("---".to_string());
+        }
+
+        let chord_payload = if chord_records.is_empty() {
+            None
+        } else {
+            let decoded = format!("{}\r", chord_records.join("\r"));
+            Some(base64::engine::general_purpose::STANDARD.encode(decoded.as_bytes()))
+        };
+
+        let mut headers = vec![format!("#LangCount={lang_count}")];
+        if !verse_order.is_empty() {
+            headers.push(format!("#VerseOrder={verse_order}"));
+        }
+        headers.push(format!("#Title={}", clean_header_value(self.title())));
+        for (index, title) in self.titles.iter().enumerate().skip(1) {
+            if !title.is_empty() {
+                headers.push(format!(
+                    "#TitleLang{}={}",
+                    index + 1,
+                    clean_header_value(title)
+                ));
+            }
+        }
+        if let Some(subtitle) = &self.subtitle {
+            headers.push(format!("#OTitle={}", clean_header_value(subtitle)));
+        }
+        if !self.artist().is_empty() {
+            headers.push(format!("#Author={}", clean_header_value(self.artist())));
+        }
+        if key.is_some() || self.key.is_some() {
+            headers.push(format!(
+                "#Key={}",
+                SimpleChord::default().format(&render_key, &ChordRepresentation::Default)
+            ));
+        }
+        if let Some(tempo) = self.tempo {
+            headers.push(format!("#Tempo={tempo}"));
+        }
+        if let Some((numerator, denominator)) = self.time {
+            headers.push(format!("#Time={numerator}/{denominator}"));
+        }
+        if let Some(chords) = chord_payload {
+            headers.push(format!("#Chords={chords}"));
+        }
+        append_preserved_headers(&mut headers, &self.tags);
+        headers.push(format!("#Editor=chordlib {}", env!("CARGO_PKG_VERSION")));
+        headers.push("#Version=3".to_string());
+        if let Some(copyright) = &self.copyright {
+            headers.push(format!("#(c)={}", clean_header_value(copyright)));
+        }
+
+        let document = headers
+            .into_iter()
+            .chain(body_lines)
+            .collect::<Vec<_>>()
+            .join("\r\n");
+        let mut output = Vec::with_capacity(document.len() + 3);
+        output.extend_from_slice(&[0xef, 0xbb, 0xbf]);
+        output.extend_from_slice(document.as_bytes());
+        output.extend_from_slice(b"\r\n");
+        Ok(output)
+    }
+}
+
+fn collect_bodies_and_flow(song: &Song) -> Result<(Vec<Body<'_>>, Vec<usize>), Error> {
+    let mut bodies = Vec::<Body<'_>>::new();
+    let mut flow = Vec::new();
+
+    for section in &song.sections {
+        let body_index = if section.lines.is_empty() {
+            bodies
+                .iter()
+                .position(|body| body.title == section.title)
+                .ok_or_else(|| {
+                    Error::InvalidSongFlow(format!(
+                        "section reference {:?} appears before its body",
+                        section.title
+                    ))
+                })?
+        } else if let Some(index) = bodies
+            .iter()
+            .position(|body| body.title == section.title && body.section.lines == section.lines)
+        {
+            index
+        } else {
+            let index = bodies.len();
+            bodies.push(Body {
+                title: section.title.clone(),
+                marker: String::new(),
+                section,
+            });
+            index
+        };
+        for _ in 0..section.repeat_count.max(1) {
+            flow.push(body_index);
+        }
+    }
+    Ok((bodies, flow))
+}
+
+fn assign_markers(bodies: &mut [Body<'_>]) {
+    let mut title_counts = BTreeMap::<String, usize>::new();
+    for body in bodies.iter() {
+        *title_counts.entry(body.title.clone()).or_default() += 1;
+    }
+    let mut occurrences = BTreeMap::<String, usize>::new();
+    for (index, body) in bodies.iter_mut().enumerate() {
+        let occurrence = occurrences.entry(body.title.clone()).or_default();
+        *occurrence += 1;
+        body.marker = if body.title.is_empty() {
+            format!("Unknown {}", index + 1)
+        } else if title_counts[&body.title] == 1 {
+            body.title.clone()
+        } else {
+            format!("{} [chordlib:{}]", body.title, occurrence)
+        };
+    }
+}
+
+fn marker_line(marker: &str) -> String {
+    if is_native_marker(marker) {
+        marker.to_string()
+    } else {
+        format!("$$M={marker}")
+    }
+}
+
+fn is_native_marker(marker: &str) -> bool {
+    let words = marker.split_whitespace().collect::<Vec<_>>();
+    if !(1..=2).contains(&words.len()) {
+        return false;
+    }
+    const NAMES: &[&str] = &[
+        "intro",
+        "vers",
+        "verse",
+        "strophe",
+        "pre-bridge",
+        "bridge",
+        "misc",
+        "pre-refrain",
+        "refrain",
+        "pre-chorus",
+        "chorus",
+        "pre-coda",
+        "zwischenspiel",
+        "instrumental",
+        "interlude",
+        "coda",
+        "ending",
+        "ende",
+        "outro",
+        "teil",
+        "part",
+        "chor",
+        "solo",
+        "breakdown",
+        "vamp",
+        "turnaround",
+        "tag",
+        "andere",
+        "unknown",
+        "unbekannt",
+        "unbenannt",
+        "hidden",
+        "invisible",
+        "comment",
+    ];
+    NAMES.iter().any(|name| words[0].eq_ignore_ascii_case(name))
+        && (words.len() == 1
+            || words[1]
+                .chars()
+                .all(|character| character.is_alphanumeric()))
+}
+
+fn song_language_count(song: &Song) -> usize {
+    song.sections
+        .iter()
+        .flat_map(|section| &section.lines)
+        .flat_map(|line| &line.parts)
+        .map(|part| part.languages.len())
+        .chain(std::iter::once(song.languages.len()))
+        .max()
+        .unwrap_or(1)
+        .max(1)
+}
+
+fn render_line(
+    line: &Line,
+    language: usize,
+    key: &SimpleChord,
+    representation: &ChordRepresentation,
+    physical_line: i32,
+) -> (String, Vec<String>) {
+    let mut lyrics = String::new();
+    let mut chords = Vec::new();
+    for part in &line.parts {
+        if language == 0
+            && let Some(chord) = &part.chord
+        {
+            chords.push(format!(
+                "{},{physical_line},{}",
+                lyrics.chars().count(),
+                chord.format(key, representation)
+            ));
+        }
+        if let Some(text) = part.languages.get(language) {
+            lyrics.push_str(text);
+        }
+    }
+    (lyrics, chords)
+}
+
+fn clean_header_value(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+fn append_preserved_headers(headers: &mut Vec<String>, tags: &BTreeMap<String, String>) {
+    for (name, value) in tags {
+        let Some(name) = name.strip_prefix("songbeamer.") else {
+            continue;
+        };
+        if name.is_empty()
+            || name.contains(['=', '\r', '\n'])
+            || value.contains(['\r', '\n'])
+            || is_reserved_header(name)
+        {
+            continue;
+        }
+        headers.push(format!("#{name}={value}"));
+    }
+}
+
+fn is_reserved_header(name: &str) -> bool {
+    matches!(
+        name,
+        "LangCount"
+            | "VerseOrder"
+            | "Title"
+            | "Author"
+            | "Key"
+            | "Tempo"
+            | "Time"
+            | "Chords"
+            | "Editor"
+            | "Version"
+            | "(c)"
+            | "OTitle"
+    ) || name.starts_with("TitleLang")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::inputs::chord_pro;
+    use crate::inputs::songbeamer;
+
+    use super::*;
+
+    #[test]
+    fn renders_bom_crlf_chords_and_semantic_round_trip() {
+        let song = chord_pro::load_string(
+            r#"{title: Example}
+{key: C}
+{artist: Writer}
+{section: Verse 1}
+[C]Hello [G]world
+{section: Chorus}
+[F]Sing
+{section: Verse 1}
+"#,
+        )
+        .expect("parse ChordPro");
+        let output = (&song)
+            .format_songbeamer(None, Some(&ChordRepresentation::Default))
+            .expect("render SongBeamer");
+        assert!(output.starts_with(&[0xef, 0xbb, 0xbf]));
+        assert!(output.windows(2).any(|window| window == b"\r\n"));
+        let text = std::str::from_utf8(&output[3..]).expect("UTF-8 output");
+        assert!(text.contains("#Chords="));
+        assert!(text.contains("#VerseOrder=Verse 1,Chorus,Verse 1"));
+
+        let again = songbeamer::load_bytes(&output).expect("round-trip SongBeamer");
+        assert_eq!(again.title(), "Example");
+        assert_eq!(again.sections.len(), 3);
+        assert!(again.sections[2].lines.is_empty());
+        assert_eq!(again.sections[0].lines, song.sections[0].lines);
+    }
+
+    #[test]
+    fn repeats_are_expanded_in_verse_order() {
+        let mut song = chord_pro::load_string(
+            "{title: Repeat}\n{key: C}\n{section: Chorus}\n[C]Sing\n{repeat: 3}\n",
+        )
+        .expect("parse ChordPro");
+        song.sections[0].repeat_count = 3;
+        let output = (&song)
+            .format_songbeamer(None, None)
+            .expect("render SongBeamer");
+        let text = std::str::from_utf8(&output[3..]).expect("UTF-8");
+        assert!(text.contains("#VerseOrder=Chorus,Chorus,Chorus"));
+    }
+
+    #[test]
+    fn same_title_variants_and_unicode_chord_columns_round_trip() {
+        let song = chord_pro::load_string(
+            "{title: Varianten}\n{key: C}\n{section: Chorus}\n[C]Grüße [G]😊\n\
+             {section: Chorus}\n[F]Anderer Text\n{section: Chorus}\n",
+        )
+        .expect("parse ChordPro variants");
+        let output = (&song)
+            .format_songbeamer(None, None)
+            .expect("render SongBeamer");
+        let text = std::str::from_utf8(&output[3..]).expect("UTF-8");
+        assert!(text.contains("$$M=Chorus [chordlib:1]"));
+        assert!(text.contains("$$M=Chorus [chordlib:2]"));
+
+        let again = songbeamer::load_bytes(&output).expect("round-trip variants");
+        assert_eq!(again.sections.len(), 3);
+        assert_eq!(again.sections[0].title, "Chorus");
+        assert_eq!(again.sections[1].title, "Chorus");
+        assert_eq!(again.sections[0].lines, song.sections[0].lines);
+        assert_eq!(again.sections[1].lines, song.sections[1].lines);
+        assert!(again.sections[2].lines.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- add BOM-aware SongBeamer `.sng` input for UTF-8, UTF-16LE/BE, and Windows-1252
- add deterministic UTF-8/BOM SongBeamer Version 3 output with native base64 chord positions
- preserve multilingual lyrics, metadata, repeats, verse order, Unicode chord columns, and same-title section variants
- support case-insensitive `.sng` conversion in the CLI
- document compatibility boundaries and the implementation plan

## Why

Chordlib supported ChordPro and Ultimate Guitar input but could not exchange songs with SongBeamer. Native SongBeamer chord data also requires byte-oriented decoding and physical-line position handling that cannot be provided by the existing ChordPro parser.

## Compatibility

The importer follows SongBeamer's BOM rules and validates malformed or unrepresentable chord records instead of silently dropping them. The exporter writes portable UTF-8 with a BOM and CRLF line endings. Presentation-only settings and the distinct display semantics of `--` and `--A` remain outside chordlib's song model.

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test` (166 passed)
- `cargo test --all-features` (168 passed)
- `cargo clippy --all-features -- -D warnings`
- `cargo doc --no-deps`
- `cargo audit`
- CLI round trip using `Spirit Fall.wp -> .sng -> .wp`

Direct validation in the proprietary SongBeamer application was not available in the development environment.
